### PR TITLE
Dynamically built and deployed next pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,34 +54,7 @@ custom:
     nextConfigDir: "/dir/to/my/nextApp"
 ```
 
-Configure the functions for the next serverless pages as you would do for any other [serverless function](https://serverless.com/framework/docs/providers/aws/guide/functions/). In the example below, is assumed next distDir is `build`.
-
-```yml
-functions:
-  home-page:
-    handler: build/serverless/pages/home.render
-    events:
-      - http:
-          path: home
-          method: get
-  about-page:
-    handler: build/serverless/pages/about.render
-    events:
-      - http:
-          path: about
-          method: get
-
-package:
-  # exclude everything, except for the page bundles
-  exclude:
-    - ./**/*
-  include:
-    # important to use {handler}.* as there will be 2 files per function handler
-    - build/serverless/pages/home.*
-    - build/serverless/pages/about.*
-```
-
-Since the next page bundles are self contained, you can exclude everything. However, make sure when you are including the page bundles, to use the pattern `build/serverless/pages/{pageName}.*`. This makes sure the compat files created by the plugin are also included in the deployment artifact.
+### REPLACE_WITH_DOCS_FOR_NEW_APPROACH
 
 ### Next configuration
 


### PR DESCRIPTION
### Motivation

Currently, to deploy a next page a function needs to be specified in the `serverless.yml` file. For example:

```yml
functions:
  home-page:
    handler: build/serverless/pages/home.render
    events:
      - http:
          path: home
          method: get
``` 

For a few pages this is fine, but applications with 10 or more pages it becomes very repetitive and difficult to maintain.

### Proposed solution

**Default plugin behaviour**

The plugin will automatically detect any pages by looking at the next build directory. For example, let say we have two pages:

`.next/serverless/pages/home.js`
`.next/serverless/pages/about.js`

Instead of declaring the functions for these pages in the `serverless.yml` file, the plugin will automatically include them in the deployment.

The following configuration will be used for each page: 

Using homePage as an example:

```yml
homePage:
    handler: /path/to/next/build/serverless/pages/home.render
    events:
      - http:
          path: /home
          method: get
```

**Overriding defaults**

The user can override a page function configuration by declaring it in the `serverless.yml` file. The plugin will merge the user provided configuration into the defaults above. Note the function name specified has to match `{name}Page`.

