### PR TITLE
Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script:
   - npm run lint
   - npm test
-  - npm run coveralls
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then npm run coveralls; fi
   - npm run integration
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 os:
-  - windows
+  # - windows
   - linux
   - osx
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script:
   - npm run lint
   - npm test
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then npm run coveralls; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm run coveralls; fi
   - npm run integration
 cache:
   directories:

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 const ServerlessPluginBuilder = require("../utils/test/ServerlessPluginBuilder");
 const parsedNextConfigurationFactory = require("../utils/test/parsedNextConfigurationFactory");
 const uploadStaticAssetsToS3 = require("../lib/uploadStaticAssetsToS3");
@@ -173,7 +173,7 @@ describe("ServerlessNextJsPlugin", () => {
     });
 
     it("should call uploadStaticAssetsToS3 with bucketName and next static dir", () => {
-      const distDir = 'build';
+      const distDir = "build";
       parseNextConfiguration.mockReturnValueOnce(
         parsedNextConfigurationFactory({
           distDir
@@ -186,7 +186,7 @@ describe("ServerlessNextJsPlugin", () => {
 
       return plugin.uploadStaticAssets().then(() => {
         expect(uploadStaticAssetsToS3).toBeCalledWith({
-          staticAssetsPath: path.join(distDir, 'static'),
+          staticAssetsPath: path.join(distDir, "static"),
           bucketName: "my-bucket",
           providerRequest: expect.any(Function)
         });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const ServerlessPluginBuilder = require("../utils/test/ServerlessPluginBuilder");
 const parsedNextConfigurationFactory = require("../utils/test/parsedNextConfigurationFactory");
 const uploadStaticAssetsToS3 = require("../lib/uploadStaticAssetsToS3");
@@ -172,9 +173,10 @@ describe("ServerlessNextJsPlugin", () => {
     });
 
     it("should call uploadStaticAssetsToS3 with bucketName and next static dir", () => {
+      const distDir = 'build';
       parseNextConfiguration.mockReturnValueOnce(
         parsedNextConfigurationFactory({
-          distDir: "build"
+          distDir
         })
       );
 
@@ -184,7 +186,7 @@ describe("ServerlessNextJsPlugin", () => {
 
       return plugin.uploadStaticAssets().then(() => {
         expect(uploadStaticAssetsToS3).toBeCalledWith({
-          staticAssetsPath: "build/static",
+          staticAssetsPath: path.join(distDir, 'static'),
           bucketName: "my-bucket",
           providerRequest: expect.any(Function)
         });

--- a/classes/NextPage.js
+++ b/classes/NextPage.js
@@ -25,7 +25,9 @@ class NextPage {
 
   get pageHandler() {
     const dir = path.dirname(this.pagePath);
-    return path.join(dir, this.pageName + ".render");
+    const handler = path.join(dir, this.pageName + ".render");
+    const posixHandler = handler.replace(/\\/g, "/");
+    return posixHandler;
   }
 
   get functionName() {

--- a/classes/PluginBuildDir.js
+++ b/classes/PluginBuildDir.js
@@ -2,13 +2,19 @@ const path = require("path");
 const fs = require("fs-extra");
 const logger = require("../utils/logger");
 
+const BUILD_DIR_NAME = "sls-next-build";
+
 class PluginBuildDir {
   constructor(nextConfigDir) {
     this.nextConfigDir = nextConfigDir;
   }
 
   get buildDir() {
-    return path.join(this.nextConfigDir, "sls-next-build");
+    return path.join(this.nextConfigDir, BUILD_DIR_NAME);
+  }
+
+  get posixBuildDir() {
+    return path.posix.join(this.nextConfigDir, BUILD_DIR_NAME);
   }
 
   setupBuildDir() {

--- a/classes/__tests__/NextPage.test.js
+++ b/classes/__tests__/NextPage.test.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 const NextPage = require("../NextPage");
 
 describe("NextPage", () => {
@@ -13,7 +13,7 @@ describe("NextPage", () => {
 
   describe("When is the index page", () => {
     const buildDir = "build";
-    const pagePath = path.join(buildDir, 'index.js');
+    const pagePath = path.join(buildDir, "index.js");
     let page;
 
     beforeEach(() => {
@@ -34,7 +34,7 @@ describe("NextPage", () => {
 
   describe("When is the _error page", () => {
     const buildDir = "build";
-    const pagePath = path.join(buildDir, '_error.js');
+    const pagePath = path.join(buildDir, "_error.js");
     let page;
 
     beforeEach(() => {
@@ -59,7 +59,7 @@ describe("NextPage", () => {
 
   describe("When is a nested page", () => {
     const buildDir = "build";
-    const pagePath = path.join(buildDir, 'categories/fridge/fridges.js');
+    const pagePath = path.join(buildDir, "categories/fridge/fridges.js");
     let page;
 
     beforeEach(() => {
@@ -104,11 +104,15 @@ describe("NextPage", () => {
     });
 
     it("should have pageCompatPath", () => {
-      expect(page.pageCompatPath).toEqual(path.join(buildDir, "admin.compat.js"));
+      expect(page.pageCompatPath).toEqual(
+        path.join(buildDir, "admin.compat.js")
+      );
     });
 
     it("should return pageOriginalPath", () => {
-      expect(page.pageOriginalPath).toEqual(path.join(buildDir, "admin.original.js"));
+      expect(page.pageOriginalPath).toEqual(
+        path.join(buildDir, "admin.original.js")
+      );
     });
 
     it("should return pageDir", () => {

--- a/classes/__tests__/NextPage.test.js
+++ b/classes/__tests__/NextPage.test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const NextPage = require("../NextPage");
 
 describe("NextPage", () => {
@@ -12,7 +13,7 @@ describe("NextPage", () => {
 
   describe("When is the index page", () => {
     const buildDir = "build";
-    const pagePath = `${buildDir}/index.js`;
+    const pagePath = path.join(buildDir, 'index.js');
     let page;
 
     beforeEach(() => {
@@ -33,7 +34,7 @@ describe("NextPage", () => {
 
   describe("When is the _error page", () => {
     const buildDir = "build";
-    const pagePath = `${buildDir}/_error.js`;
+    const pagePath = path.join(buildDir, '_error.js');
     let page;
 
     beforeEach(() => {
@@ -58,7 +59,7 @@ describe("NextPage", () => {
 
   describe("When is a nested page", () => {
     const buildDir = "build";
-    const pagePath = `${buildDir}/categories/fridge/fridges.js`;
+    const pagePath = path.join(buildDir, 'categories/fridge/fridges.js');
     let page;
 
     beforeEach(() => {
@@ -103,11 +104,11 @@ describe("NextPage", () => {
     });
 
     it("should have pageCompatPath", () => {
-      expect(page.pageCompatPath).toEqual(`${buildDir}/admin.compat.js`);
+      expect(page.pageCompatPath).toEqual(path.join(buildDir, "admin.compat.js"));
     });
 
     it("should return pageOriginalPath", () => {
-      expect(page.pageOriginalPath).toEqual(`${buildDir}/admin.original.js`);
+      expect(page.pageOriginalPath).toEqual(path.join(buildDir, "admin.original.js"));
     });
 
     it("should return pageDir", () => {

--- a/classes/__tests__/NextPage.test.js
+++ b/classes/__tests__/NextPage.test.js
@@ -79,6 +79,20 @@ describe("NextPage", () => {
     });
   });
 
+  describe("When pagePath has win format", () => {
+    const buildDir = "build";
+    const pagePath = `${buildDir}\\admin.js`;
+    let page;
+
+    beforeEach(() => {
+      page = new NextPage(pagePath);
+    });
+
+    it("should return posix pageHandler", () => {
+      expect(page.pageHandler).toEqual("build/admin.render");
+    });
+  });
+
   describe("When a new instance is created", () => {
     const buildDir = "build";
     const pagePath = `${buildDir}/admin.js`;

--- a/classes/__tests__/PluginBuildDir.test.js
+++ b/classes/__tests__/PluginBuildDir.test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const fs = require("fs-extra");
 const PluginBuildDir = require("../PluginBuildDir");
 const logger = require("../../utils/logger");
@@ -17,14 +18,19 @@ describe("PluginBuildDir", () => {
 
   describe("When a new instance is created", () => {
     let pluginBuildDir;
+    let nextConfigDir;
 
     beforeEach(() => {
-      const nextConfigDir = "path/to/nextApp";
+      nextConfigDir = "path/to/nextApp";
       pluginBuildDir = new PluginBuildDir(nextConfigDir);
     });
 
-    it("should have buildDir one level above nextBuild", () => {
-      expect(pluginBuildDir.buildDir).toEqual("path/to/nextApp/sls-next-build");
+    it("should have buildDir at same level as next config.", () => {
+      expect(pluginBuildDir.buildDir).toEqual(path.join(nextConfigDir, 'sls-next-build'));
+    });
+
+    it("should have posixBuildDir regardless the platform", () => {
+      expect(pluginBuildDir.posixBuildDir).toEqual("path/to/nextApp/sls-next-build");
     });
   });
 

--- a/classes/__tests__/PluginBuildDir.test.js
+++ b/classes/__tests__/PluginBuildDir.test.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 const fs = require("fs-extra");
 const PluginBuildDir = require("../PluginBuildDir");
 const logger = require("../../utils/logger");
@@ -26,11 +26,15 @@ describe("PluginBuildDir", () => {
     });
 
     it("should have buildDir at same level as next config.", () => {
-      expect(pluginBuildDir.buildDir).toEqual(path.join(nextConfigDir, 'sls-next-build'));
+      expect(pluginBuildDir.buildDir).toEqual(
+        path.join(nextConfigDir, "sls-next-build")
+      );
     });
 
     it("should have posixBuildDir regardless the platform", () => {
-      expect(pluginBuildDir.posixBuildDir).toEqual("path/to/nextApp/sls-next-build");
+      expect(pluginBuildDir.posixBuildDir).toEqual(
+        "path/to/nextApp/sls-next-build"
+      );
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class ServerlessNextJsPlugin {
     const servicePackage = this.serverless.service.package;
 
     servicePackage.include = servicePackage.include || [];
-    servicePackage.include.push(path.join(pluginBuildDir.buildDir, "**"));
+    servicePackage.include.push(path.posix.join(pluginBuildDir.posixBuildDir, "**"));
     return build(pluginBuildDir, this.getPluginConfigValue("pageConfig")).then(
       nextPages => this.setNextPages(nextPages)
     );

--- a/index.js
+++ b/index.js
@@ -53,7 +53,9 @@ class ServerlessNextJsPlugin {
     const servicePackage = this.serverless.service.package;
 
     servicePackage.include = servicePackage.include || [];
-    servicePackage.include.push(path.posix.join(pluginBuildDir.posixBuildDir, "**"));
+    servicePackage.include.push(
+      path.posix.join(pluginBuildDir.posixBuildDir, "**")
+    );
     return build(pluginBuildDir, this.getPluginConfigValue("pageConfig")).then(
       nextPages => this.setNextPages(nextPages)
     );

--- a/lib/__tests__/copyBuildFiles.test.js
+++ b/lib/__tests__/copyBuildFiles.test.js
@@ -39,7 +39,7 @@ describe("copyBuildFiles", () => {
 
     it("should copy serverless pages folder from next build directory", () => {
       expect(fse.copy).toBeCalledWith(
-        path.join(nextBuildDir, 'serverless/pages'),
+        path.join(nextBuildDir, "serverless/pages"),
         pluginBuildDir
       );
     });
@@ -51,7 +51,7 @@ describe("copyBuildFiles", () => {
     it("should call fs copy with the compatLayer file", () => {
       expect(fse.copy).toBeCalledWith(
         path.join(__dirname, "..", `compatLayer.js`),
-        path.join(pluginBuildDir, 'compatLayer.js')
+        path.join(pluginBuildDir, "compatLayer.js")
       );
     });
   });

--- a/lib/__tests__/copyBuildFiles.test.js
+++ b/lib/__tests__/copyBuildFiles.test.js
@@ -13,8 +13,8 @@ describe("copyBuildFiles", () => {
 
   describe("when page files are copied correctly", () => {
     let pluginBuildDirObj;
-    const pluginBuildDir = "path/to/sls-next-build";
-    const nextBuildDir = "path/to/.next";
+    const pluginBuildDir = path.normalize("path/to/sls-next-build");
+    const nextBuildDir = path.normalize("path/to/.next");
 
     beforeEach(() => {
       fse.copy.mockResolvedValue(null);
@@ -39,7 +39,7 @@ describe("copyBuildFiles", () => {
 
     it("should copy serverless pages folder from next build directory", () => {
       expect(fse.copy).toBeCalledWith(
-        `${nextBuildDir}/serverless/pages`,
+        path.join(nextBuildDir, 'serverless/pages'),
         pluginBuildDir
       );
     });
@@ -51,7 +51,7 @@ describe("copyBuildFiles", () => {
     it("should call fs copy with the compatLayer file", () => {
       expect(fse.copy).toBeCalledWith(
         path.join(__dirname, "..", `compatLayer.js`),
-        `${pluginBuildDir}/compatLayer.js`
+        path.join(pluginBuildDir, 'compatLayer.js')
       );
     });
   });

--- a/lib/__tests__/getCompatLayerCode.test.js
+++ b/lib/__tests__/getCompatLayerCode.test.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 const getCompatLayerCode = require("../getCompatLayerCode");
 
 describe("getCompatLayerCode", () => {

--- a/lib/__tests__/getCompatLayerCode.test.js
+++ b/lib/__tests__/getCompatLayerCode.test.js
@@ -1,30 +1,31 @@
+const path = require('path');
 const getCompatLayerCode = require("../getCompatLayerCode");
 
 describe("getCompatLayerCode", () => {
   it("should require compatLayer", () => {
     const compatHandlerContent = getCompatLayerCode(
-      "sls-next-build/my-page.js"
+      path.join("sls-next-build", "my-page.js")
     );
     expect(compatHandlerContent).toContain('require("./compatLayer")');
   });
 
   it("should require compatLayer with correct path when page is nested", () => {
     const compatHandlerContent = getCompatLayerCode(
-      "sls-next-build/categories/fridge/fridges.js"
+      path.join("sls-next-build", "categories/fridge/fridges.js")
     );
     expect(compatHandlerContent).toContain('require("../../compatLayer")');
   });
 
   it("should require next page provided", () => {
     const compatHandlerContent = getCompatLayerCode(
-      "sls-next-build/my-page.js"
+      path.join("sls-next-build", "my-page.js")
     );
     expect(compatHandlerContent).toContain('require("./my-page.original.js")');
   });
 
   it("should export render method", () => {
     const compatHandlerContent = getCompatLayerCode(
-      "sls-next-build/my-page.js"
+      path.join("sls-next-build", "my-page.js")
     );
     expect(compatHandlerContent).toContain("module.exports.render");
   });

--- a/lib/__tests__/getNextPagesFromBuildDir.test.js
+++ b/lib/__tests__/getNextPagesFromBuildDir.test.js
@@ -26,7 +26,7 @@ describe("getNextPagesFromBuildDir", () => {
   it("should return an empty array when there are no pages", () => {
     expect.assertions(1);
 
-    const buildDir = path.normalize("/path/to/build/dir")
+    const buildDir = path.normalize("/path/to/build/dir");
 
     const getPagesPromise = getNextPagesFromBuildDir(buildDir).then(
       nextPages => {
@@ -48,9 +48,9 @@ describe("getNextPagesFromBuildDir", () => {
     const promise = getNextPagesFromBuildDir(buildDir).then(nextPages => {
       expect(nextPages).toHaveLength(2);
       expect(nextPages[0].pageName).toEqual("index");
-      expect(nextPages[0].pagePath).toEqual(path.join('build', 'index.js'));
+      expect(nextPages[0].pagePath).toEqual(path.join("build", "index.js"));
       expect(nextPages[1].pageName).toEqual("about");
-      expect(nextPages[1].pagePath).toEqual(path.join('build', 'about.js'));
+      expect(nextPages[1].pagePath).toEqual(path.join("build", "about.js"));
     });
 
     mockedStream.emit("data", {
@@ -75,7 +75,7 @@ describe("getNextPagesFromBuildDir", () => {
       about: aboutPageConfigOverride
     };
 
-    const buildDir = path.normalize('/path/to/build');
+    const buildDir = path.normalize("/path/to/build");
 
     const promise = getNextPagesFromBuildDir(buildDir, pageConfig).then(
       nextPages => {
@@ -98,7 +98,7 @@ describe("getNextPagesFromBuildDir", () => {
   it("should log pages found", () => {
     expect.assertions(1);
 
-    const buildDir = path.normalize('/path/to/build');
+    const buildDir = path.normalize("/path/to/build");
 
     const promise = getNextPagesFromBuildDir(buildDir).then(() => {
       expect(logger.log).toBeCalledWith(`Found 1 next page(s)`);
@@ -136,14 +136,12 @@ describe("getNextPagesFromBuildDir", () => {
   it("should skip compatLayer file", () => {
     expect.assertions(2);
 
-    const buildDir = path.normalize('/path/to/build');
+    const buildDir = path.normalize("/path/to/build");
 
-    const promise = getNextPagesFromBuildDir(buildDir).then(
-      nextPages => {
-        expect(nextPages).toHaveLength(1);
-        expect(nextPages[0].pageName).toEqual("home");
-      }
-    );
+    const promise = getNextPagesFromBuildDir(buildDir).then(nextPages => {
+      expect(nextPages).toHaveLength(1);
+      expect(nextPages[0].pageName).toEqual("home");
+    });
 
     mockedStream.emit("data", { path: path.join(buildDir, "compatLayer.js") });
     mockedStream.emit("data", { path: path.join(buildDir, "home.js") });
@@ -161,9 +159,13 @@ describe("getNextPagesFromBuildDir", () => {
     const promise = getNextPagesFromBuildDir(buildDir).then(nextPages => {
       expect(nextPages).toHaveLength(2);
       expect(nextPages[0].pageName).toEqual("hello-world");
-      expect(nextPages[0].pagePath).toEqual(path.join(buildDir, "one", "hello-world.js"));
+      expect(nextPages[0].pagePath).toEqual(
+        path.join(buildDir, "one", "hello-world.js")
+      );
       expect(nextPages[1].pageName).toEqual("hello-world");
-      expect(nextPages[1].pagePath).toEqual(path.join(buildDir, "one", "two", "hello-world.js"));
+      expect(nextPages[1].pagePath).toEqual(
+        path.join(buildDir, "one", "two", "hello-world.js")
+      );
     });
 
     mockedStream.emit("data", {

--- a/lib/__tests__/getNextPagesFromBuildDir.test.js
+++ b/lib/__tests__/getNextPagesFromBuildDir.test.js
@@ -26,7 +26,9 @@ describe("getNextPagesFromBuildDir", () => {
   it("should return an empty array when there are no pages", () => {
     expect.assertions(1);
 
-    const getPagesPromise = getNextPagesFromBuildDir("/path/to/build/dir").then(
+    const buildDir = path.normalize("/path/to/build/dir")
+
+    const getPagesPromise = getNextPagesFromBuildDir(buildDir).then(
       nextPages => {
         expect(nextPages).toEqual([]);
       }
@@ -46,9 +48,9 @@ describe("getNextPagesFromBuildDir", () => {
     const promise = getNextPagesFromBuildDir(buildDir).then(nextPages => {
       expect(nextPages).toHaveLength(2);
       expect(nextPages[0].pageName).toEqual("index");
-      expect(nextPages[0].pagePath).toEqual("build/index.js");
+      expect(nextPages[0].pagePath).toEqual(path.join('build', 'index.js'));
       expect(nextPages[1].pageName).toEqual("about");
-      expect(nextPages[1].pagePath).toEqual("build/about.js");
+      expect(nextPages[1].pagePath).toEqual(path.join('build', 'about.js'));
     });
 
     mockedStream.emit("data", {
@@ -73,7 +75,9 @@ describe("getNextPagesFromBuildDir", () => {
       about: aboutPageConfigOverride
     };
 
-    const promise = getNextPagesFromBuildDir("/path/to/build", pageConfig).then(
+    const buildDir = path.normalize('/path/to/build');
+
+    const promise = getNextPagesFromBuildDir(buildDir, pageConfig).then(
       nextPages => {
         expect(nextPages[0].serverlessFunctionOverrides).toEqual(
           indexPageConfigOverride
@@ -84,8 +88,8 @@ describe("getNextPagesFromBuildDir", () => {
       }
     );
 
-    mockedStream.emit("data", { path: `/path/to/build/index.js` });
-    mockedStream.emit("data", { path: `/path/to/build/about.js` });
+    mockedStream.emit("data", { path: path.join(buildDir, "index.js") });
+    mockedStream.emit("data", { path: path.join(buildDir, "about.js") });
     mockedStream.emit("end");
 
     return promise;
@@ -94,11 +98,13 @@ describe("getNextPagesFromBuildDir", () => {
   it("should log pages found", () => {
     expect.assertions(1);
 
-    const promise = getNextPagesFromBuildDir("/path/to/build").then(() => {
+    const buildDir = path.normalize('/path/to/build');
+
+    const promise = getNextPagesFromBuildDir(buildDir).then(() => {
       expect(logger.log).toBeCalledWith(`Found 1 next page(s)`);
     });
 
-    mockedStream.emit("data", { path: `/path/to/build/about.js` });
+    mockedStream.emit("data", { path: path.join(buildDir, "about.js") });
     mockedStream.emit("end");
 
     return promise;
@@ -107,7 +113,7 @@ describe("getNextPagesFromBuildDir", () => {
   it("should skip _app and _document pages", () => {
     expect.assertions(2);
 
-    const buildDir = "./build";
+    const buildDir = path.normalize("./build");
     const resolvedBuildDir = path.resolve(buildDir);
 
     const promise = getNextPagesFromBuildDir(buildDir).then(nextPages => {
@@ -130,15 +136,17 @@ describe("getNextPagesFromBuildDir", () => {
   it("should skip compatLayer file", () => {
     expect.assertions(2);
 
-    const promise = getNextPagesFromBuildDir("/path/to/build").then(
+    const buildDir = path.normalize('/path/to/build');
+
+    const promise = getNextPagesFromBuildDir(buildDir).then(
       nextPages => {
         expect(nextPages).toHaveLength(1);
         expect(nextPages[0].pageName).toEqual("home");
       }
     );
 
-    mockedStream.emit("data", { path: `/path/to/build/compatLayer.js` });
-    mockedStream.emit("data", { path: `/path/to/build/home.js` });
+    mockedStream.emit("data", { path: path.join(buildDir, "compatLayer.js") });
+    mockedStream.emit("data", { path: path.join(buildDir, "home.js") });
     mockedStream.emit("end");
 
     return promise;
@@ -147,22 +155,22 @@ describe("getNextPagesFromBuildDir", () => {
   it("should handle nested pages", () => {
     expect.assertions(5);
 
-    const buildDir = "./build";
+    const buildDir = path.normalize("./build");
     const resolvedBuildDir = path.resolve(buildDir);
 
     const promise = getNextPagesFromBuildDir(buildDir).then(nextPages => {
       expect(nextPages).toHaveLength(2);
       expect(nextPages[0].pageName).toEqual("hello-world");
-      expect(nextPages[0].pagePath).toEqual("build/one/hello-world.js");
+      expect(nextPages[0].pagePath).toEqual(path.join(buildDir, "one", "hello-world.js"));
       expect(nextPages[1].pageName).toEqual("hello-world");
-      expect(nextPages[1].pagePath).toEqual("build/one/two/hello-world.js");
+      expect(nextPages[1].pagePath).toEqual(path.join(buildDir, "one", "two", "hello-world.js"));
     });
 
     mockedStream.emit("data", {
-      path: path.join(resolvedBuildDir, "one/hello-world.js")
+      path: path.join(resolvedBuildDir, "one", "hello-world.js")
     });
     mockedStream.emit("data", {
-      path: path.join(resolvedBuildDir, "one/two/hello-world.js")
+      path: path.join(resolvedBuildDir, "one", "two", "hello-world.js")
     });
     mockedStream.emit("end");
 
@@ -172,7 +180,7 @@ describe("getNextPagesFromBuildDir", () => {
   it("should skip page directories", () => {
     expect.assertions(1);
 
-    const buildDir = "./build";
+    const buildDir = path.normalize("./build");
     const resolvedBuildDir = path.resolve(buildDir);
     fs.lstatSync.mockReturnValue({ isDirectory: () => true });
 
@@ -181,10 +189,10 @@ describe("getNextPagesFromBuildDir", () => {
     });
 
     mockedStream.emit("data", {
-      path: path.join(resolvedBuildDir, "one/")
+      path: path.join(resolvedBuildDir, "one")
     });
     mockedStream.emit("data", {
-      path: path.join(resolvedBuildDir, "one/two/")
+      path: path.join(resolvedBuildDir, "one", "two")
     });
     mockedStream.emit("end");
 

--- a/lib/__tests__/rewritePageHandlers.js
+++ b/lib/__tests__/rewritePageHandlers.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const fs = require("fs");
 const rewritePageHandlers = require("../rewritePageHandlers");
 const getCompatLayerCode = require("../getCompatLayerCode");
@@ -22,8 +23,8 @@ describe("rewritePageHandlers", () => {
       getCompatLayerCode.mockReturnValue("module.exports.render={...}");
 
       rewritePageHandlersPromise = rewritePageHandlers([
-        new NextPage(`${pagesDir}/home.js`),
-        new NextPage(`${pagesDir}/about.js`)
+        new NextPage(path.join(pagesDir, "home.js")),
+        new NextPage(path.join(pagesDir, "about.js"))
       ]);
 
       return rewritePageHandlersPromise;
@@ -43,19 +44,19 @@ describe("rewritePageHandlers", () => {
     });
 
     it("should call getCompatLayerCode with the next page path", () => {
-      expect(getCompatLayerCode).toBeCalledWith(`${pagesDir}/home.js`);
-      expect(getCompatLayerCode).toBeCalledWith(`${pagesDir}/about.js`);
+      expect(getCompatLayerCode).toBeCalledWith(path.join(pagesDir, "home.js"));
+      expect(getCompatLayerCode).toBeCalledWith(path.join(pagesDir, "about.js"));
     });
 
     it("should write new js files with the compat layer code", () => {
       expect(fs.writeFile).toBeCalledWith(
-        `${pagesDir}/home.compat.js`,
+        path.join(pagesDir, "home.compat.js"),
         "module.exports.render={...}",
         expect.any(Function)
       );
 
       expect(fs.writeFile).toBeCalledWith(
-        `${pagesDir}/about.compat.js`,
+        path.join(pagesDir, "about.compat.js"),
         "module.exports.render={...}",
         expect.any(Function)
       );
@@ -65,14 +66,14 @@ describe("rewritePageHandlers", () => {
       fs.rename.mockImplementation((fileName, newFileName, cb) => cb(null, ""));
 
       expect(fs.rename).toBeCalledWith(
-        `${pagesDir}/home.js`,
-        `${pagesDir}/home.original.js`,
+        path.join(pagesDir, "home.js"),        
+        path.join(pagesDir, "home.original.js"),        
         expect.any(Function)
       );
 
       expect(fs.rename).toBeCalledWith(
-        `${pagesDir}/about.js`,
-        `${pagesDir}/about.original.js`,
+        path.join(pagesDir, "about.js"),        
+        path.join(pagesDir, "about.original.js"),    
         expect.any(Function)
       );
     });
@@ -81,14 +82,14 @@ describe("rewritePageHandlers", () => {
       expect.assertions(2);
 
       expect(fs.rename).toBeCalledWith(
-        `${pagesDir}/home.compat.js`,
-        `${pagesDir}/home.js`,
+        path.join(pagesDir, "home.compat.js"),        
+        path.join(pagesDir, "home.js"),
         expect.any(Function)
       );
 
       expect(fs.rename).toBeCalledWith(
-        `${pagesDir}/about.compat.js`,
-        `${pagesDir}/about.js`,
+        path.join(pagesDir, "about.compat.js"),        
+        path.join(pagesDir, "about.js"),
         expect.any(Function)
       );
     });

--- a/lib/__tests__/rewritePageHandlers.js
+++ b/lib/__tests__/rewritePageHandlers.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 const fs = require("fs");
 const rewritePageHandlers = require("../rewritePageHandlers");
 const getCompatLayerCode = require("../getCompatLayerCode");
@@ -45,7 +45,9 @@ describe("rewritePageHandlers", () => {
 
     it("should call getCompatLayerCode with the next page path", () => {
       expect(getCompatLayerCode).toBeCalledWith(path.join(pagesDir, "home.js"));
-      expect(getCompatLayerCode).toBeCalledWith(path.join(pagesDir, "about.js"));
+      expect(getCompatLayerCode).toBeCalledWith(
+        path.join(pagesDir, "about.js")
+      );
     });
 
     it("should write new js files with the compat layer code", () => {
@@ -66,14 +68,14 @@ describe("rewritePageHandlers", () => {
       fs.rename.mockImplementation((fileName, newFileName, cb) => cb(null, ""));
 
       expect(fs.rename).toBeCalledWith(
-        path.join(pagesDir, "home.js"),        
-        path.join(pagesDir, "home.original.js"),        
+        path.join(pagesDir, "home.js"),
+        path.join(pagesDir, "home.original.js"),
         expect.any(Function)
       );
 
       expect(fs.rename).toBeCalledWith(
-        path.join(pagesDir, "about.js"),        
-        path.join(pagesDir, "about.original.js"),    
+        path.join(pagesDir, "about.js"),
+        path.join(pagesDir, "about.original.js"),
         expect.any(Function)
       );
     });
@@ -82,13 +84,13 @@ describe("rewritePageHandlers", () => {
       expect.assertions(2);
 
       expect(fs.rename).toBeCalledWith(
-        path.join(pagesDir, "home.compat.js"),        
+        path.join(pagesDir, "home.compat.js"),
         path.join(pagesDir, "home.js"),
         expect.any(Function)
       );
 
       expect(fs.rename).toBeCalledWith(
-        path.join(pagesDir, "about.compat.js"),        
+        path.join(pagesDir, "about.compat.js"),
         path.join(pagesDir, "about.js"),
         expect.any(Function)
       );

--- a/lib/__tests__/uploadStaticAssetsToS3.test.js
+++ b/lib/__tests__/uploadStaticAssetsToS3.test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const fs = require("fs");
 const walkDir = require("klaw");
 const mime = require("mime");
@@ -29,7 +30,7 @@ describe("uploadStaticAssetsToS3", () => {
     const bucketName = "my-bucket";
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: ".next/static",
+      staticAssetsPath: path.join(".next", "static"),
       bucketName,
       providerRequest: () => {}
     }).then(() => {
@@ -39,7 +40,7 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/foo.js"
+      path: path.normalize("users/foo/static/chunks/foo.js")      
     });
     mockedStream.emit("end");
 
@@ -50,7 +51,7 @@ describe("uploadStaticAssetsToS3", () => {
     expect.assertions(1);
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: ".next/static",
+      staticAssetsPath: path.join(".next", "static"),
       providerRequest: () => {}
     }).then(() => {
       expect(logger.log).toBeCalledWith(
@@ -59,7 +60,7 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/foo.js"
+      path: path.normalize("users/foo/static/chunks/foo.js")      
     });
     mockedStream.emit("end");
 
@@ -70,14 +71,14 @@ describe("uploadStaticAssetsToS3", () => {
     expect.assertions(1);
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: ".next/static",
+      staticAssetsPath: path.join(".next", "static"),
       providerRequest: () => {}
     }).then(() => {
-      expect(walkDir).toBeCalledWith(".next/static");
+      expect(walkDir).toBeCalledWith(path.join(".next", "static"));
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/foo.js"
+      path: path.normalize("users/foo/static/chunks/foo.js")      
     });
     mockedStream.emit("end");
 
@@ -88,14 +89,14 @@ describe("uploadStaticAssetsToS3", () => {
     expect.assertions(1);
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: "build/static",
+      staticAssetsPath: path.join("build", "static"),      
       providerRequest: () => {}
     }).then(() => {
-      expect(walkDir).toBeCalledWith("build/static");
+      expect(walkDir).toBeCalledWith(path.join("build", "static"));
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/foo.js"
+      path: path.normalize("users/foo/static/chunks/foo.js")      
     });
     mockedStream.emit("end");
 
@@ -113,12 +114,12 @@ describe("uploadStaticAssetsToS3", () => {
     mime.getType.mockImplementation(() => "application/foo");
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: "build/static",
+      staticAssetsPath: path.join('build', 'static'),
       providerRequest,
       bucketName
     }).then(() => {
       expect(mime.getType).toBeCalledWith(
-        expect.stringContaining("chunks/foo.js")
+        expect.stringContaining(path.normalize("chunks/foo.js"))
       );
       expect(providerRequest).toBeCalledWith(
         "S3",
@@ -133,7 +134,7 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/foo.js"
+      path: path.normalize("/users/foo/prj/.next/static/chunks/foo.js")
     });
     mockedStream.emit("end");
 
@@ -148,14 +149,14 @@ describe("uploadStaticAssetsToS3", () => {
     const providerRequest = jest.fn();
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: "build/static",
+      staticAssetsPath: path.join("build", "static"),
       providerRequest
     }).then(() => {
       expect(providerRequest).not.toBeCalled();
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks"
+      path: path.normalize("/users/foo/prj/.next/static/chunks")
     });
     mockedStream.emit("end");
 
@@ -175,10 +176,10 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/1.js"
+      path: path.normalize("/users/foo/prj/.next/static/chunks/1.js")
     });
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/2.js"
+      path: path.normalize("/users/foo/prj/.next/static/chunks/2.js")
     });
     mockedStream.emit("end");
 
@@ -191,17 +192,17 @@ describe("uploadStaticAssetsToS3", () => {
     const providerRequest = jest.fn().mockRejectedValueOnce("Error");
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: "build/static",
+      staticAssetsPath: path.join("build", "static"),
       providerRequest
     }).catch(err => {
       expect(err.message).toContain("File upload failed");
     });
 
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/1.js"
+      path: path.normalize("/users/foo/prj/.next/static/chunks/1.js")
     });
     mockedStream.emit("data", {
-      path: "/users/foo/prj/.next/static/chunks/2.js"
+      path: path.normalize("/users/foo/prj/.next/static/chunks/2.js")
     });
     mockedStream.emit("end");
 

--- a/lib/__tests__/uploadStaticAssetsToS3.test.js
+++ b/lib/__tests__/uploadStaticAssetsToS3.test.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 const fs = require("fs");
 const walkDir = require("klaw");
 const mime = require("mime");
@@ -40,7 +40,7 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: path.normalize("users/foo/static/chunks/foo.js")      
+      path: path.normalize("users/foo/static/chunks/foo.js")
     });
     mockedStream.emit("end");
 
@@ -60,7 +60,7 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: path.normalize("users/foo/static/chunks/foo.js")      
+      path: path.normalize("users/foo/static/chunks/foo.js")
     });
     mockedStream.emit("end");
 
@@ -78,7 +78,7 @@ describe("uploadStaticAssetsToS3", () => {
     });
 
     mockedStream.emit("data", {
-      path: path.normalize("users/foo/static/chunks/foo.js")      
+      path: path.normalize("users/foo/static/chunks/foo.js")
     });
     mockedStream.emit("end");
 
@@ -89,14 +89,14 @@ describe("uploadStaticAssetsToS3", () => {
     expect.assertions(1);
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: path.join("build", "static"),      
+      staticAssetsPath: path.join("build", "static"),
       providerRequest: () => {}
     }).then(() => {
       expect(walkDir).toBeCalledWith(path.join("build", "static"));
     });
 
     mockedStream.emit("data", {
-      path: path.normalize("users/foo/static/chunks/foo.js")      
+      path: path.normalize("users/foo/static/chunks/foo.js")
     });
     mockedStream.emit("end");
 
@@ -114,7 +114,7 @@ describe("uploadStaticAssetsToS3", () => {
     mime.getType.mockImplementation(() => "application/foo");
 
     const promise = uploadStaticAssetsToS3({
-      staticAssetsPath: path.join('build', 'static'),
+      staticAssetsPath: path.join("build", "static"),
       providerRequest,
       bucketName
     }).then(() => {

--- a/lib/uploadStaticAssetsToS3.js
+++ b/lib/uploadStaticAssetsToS3.js
@@ -18,15 +18,16 @@ const uploadStaticAssetsToS3 = ({
       .on("data", item => {
         const itemPath = item.path;
         const isFile = !fs.lstatSync(itemPath).isDirectory();
+        const posixItemPath = item.path.replace(/\\/g, '/');
 
         if (isFile) {
           uploadPromises.push(
             providerRequest("S3", "upload", {
               ACL: "public-read",
               Bucket: bucketName,
-              Key: path.join(
+              Key: path.posix.join(
                 "_next",
-                itemPath.substring(itemPath.indexOf("/static"), itemPath.length)
+                posixItemPath.substring(posixItemPath.indexOf("/static"), posixItemPath.length)
               ),
               ContentType: mime.getType(itemPath),
               Body: fs.createReadStream(itemPath)

--- a/lib/uploadStaticAssetsToS3.js
+++ b/lib/uploadStaticAssetsToS3.js
@@ -18,7 +18,7 @@ const uploadStaticAssetsToS3 = ({
       .on("data", item => {
         const itemPath = item.path;
         const isFile = !fs.lstatSync(itemPath).isDirectory();
-        const posixItemPath = item.path.replace(/\\/g, '/');
+        const posixItemPath = item.path.replace(/\\/g, "/");
 
         if (isFile) {
           uploadPromises.push(
@@ -27,7 +27,10 @@ const uploadStaticAssetsToS3 = ({
               Bucket: bucketName,
               Key: path.posix.join(
                 "_next",
-                posixItemPath.substring(posixItemPath.indexOf("/static"), posixItemPath.length)
+                posixItemPath.substring(
+                  posixItemPath.indexOf("/static"),
+                  posixItemPath.length
+                )
               ),
               ContentType: mime.getType(itemPath),
               Body: fs.createReadStream(itemPath)

--- a/utils/test/getServerlessExec.js
+++ b/utils/test/getServerlessExec.js
@@ -1,10 +1,16 @@
 const path = require("path");
 
-const serverlessExec = path.join(
+let serverlessExec = path.join(
   __dirname,
   "..",
   "..",
   "node_modules/.bin/serverless"
 );
 
-module.exports = serverlessExec;
+const isWin = process.platform === "win32";
+
+if (isWin) {
+  serverlessExec += '.cmd';
+}
+
+module.exports = path.resolve(serverlessExec);

--- a/utils/test/getServerlessExec.js
+++ b/utils/test/getServerlessExec.js
@@ -10,7 +10,7 @@ let serverlessExec = path.join(
 const isWin = process.platform === "win32";
 
 if (isWin) {
-  serverlessExec += '.cmd';
+  serverlessExec += ".cmd";
 }
 
 module.exports = path.resolve(serverlessExec);


### PR DESCRIPTION
Fixes for Windows platform:
- Fixes numerous unit tests assuming only posix filepaths are used
- Fixes integration tests
- Bugfixes where again posix filepaths are assumed to always be the case