### PR TITLE
fix: resolve relative path to custom handler

### DIFF
--- a/lib/__tests__/getFactoryHandlerCode.test.js
+++ b/lib/__tests__/getFactoryHandlerCode.test.js
@@ -43,4 +43,20 @@ describe("getFactoryHandlerCode", () => {
     );
     expect(compatHandlerContent).toContain("module.exports.render");
   });
+
+  it("should require custom handler", () => {
+    const compatHandlerContent = getFactoryHandlerCode(
+      path.join(PluginBuildDir.BUILD_DIR_NAME, "my-page.js"),
+      "./myHandler.js"
+    );
+    expect(compatHandlerContent).toContain('require("./myHandler.js")');
+  });
+
+  it("should require custom handler when page is nested with correct relative path", () => {
+    const compatHandlerContent = getFactoryHandlerCode(
+      path.join(PluginBuildDir.BUILD_DIR_NAME, "foo/bar/my-page.js"),
+      "./myHandler.js"
+    );
+    expect(compatHandlerContent).toContain('require("../../myHandler.js")');
+  });
 });

--- a/lib/getFactoryHandlerCode.js
+++ b/lib/getFactoryHandlerCode.js
@@ -13,11 +13,11 @@ const lambdaHandlerWithFactory = `
 `;
 
 module.exports = (jsHandlerPath, customHandlerPath) => {
-  // Convert Windows path to POSIX
+  // convert windows path to POSIX
   jsHandlerPath = jsHandlerPath.replace(/\\/g, "/");
   const basename = path.basename(jsHandlerPath, ".js");
 
-  // Get relative path to custom handler
+  // get relative path to custom handler
   if (customHandlerPath) {
     let pathDepth = jsHandlerPath.split("/").length - 2;
     if (pathDepth > 0) {

--- a/lib/getFactoryHandlerCode.js
+++ b/lib/getFactoryHandlerCode.js
@@ -13,7 +13,21 @@ const lambdaHandlerWithFactory = `
 `;
 
 module.exports = (jsHandlerPath, customHandlerPath) => {
+  // Convert Windows path to POSIX
+  jsHandlerPath = jsHandlerPath.replace(/\\/g, "/");
   const basename = path.basename(jsHandlerPath, ".js");
+
+  // Get relative path to custom handler
+  if (customHandlerPath) {
+    let pathDepth = jsHandlerPath.split("/").length - 2;
+    if (pathDepth > 0) {
+      customHandlerPath = customHandlerPath.replace("./", "");
+      while (pathDepth-- > 0) {
+        customHandlerPath = `../${customHandlerPath}`;
+      }
+    }
+  }
+
   return lambdaHandlerWithFactory
     .replace(PAGE_BUNDLE_PATH, `./${basename}.original.js`)
     .replace(


### PR DESCRIPTION
This PR will resolve the relative path to the custom handler when the page is located in a sub-directory.