### PR TITLE
feat: global page config

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,23 @@ custom:
 
 The example above will deploy the `about` page function with a smaller `memorySize` and the home page with a higher `timeout` than the default values.
 
+You can also add configuration for all pages by adding an asterisk entry (`*`), this is especially useful if you want to add [layers](https://serverless.com/framework/docs/providers/aws/guide/layers/) to all your page handlers.
+
+```yml
+plugins:
+  - serverless-nextjs-plugin
+
+custom:
+  serverless-nextjs:
+    nextConfigDir: ./
+    pageConfig:
+      '*':
+        layers:
+          - arn:aws:lambda:${self:provider.region}:553035198032:layer:nodejs12:1
+```
+
+The example above will deploy all page functions connected to a layer that includes the Node.js 12 binary.
+
 You can set any function property described [here](https://serverless.com/framework/docs/providers/aws/guide/functions#configuration). The values provided will be merged onto the plugin defaults.
 
 ## Custom page routing

--- a/lib/__tests__/getNextPagesFromBuildDir.test.js
+++ b/lib/__tests__/getNextPagesFromBuildDir.test.js
@@ -94,6 +94,37 @@ describe("getNextPagesFromBuildDir", () => {
     return promise;
   });
 
+  it("should pass asterisk pageConfig to all pages", () => {
+    expect.assertions(2);
+
+    const asteriskPageConfigOverride = { foo: "bar" };
+
+    const pageConfig = {
+      "*": asteriskPageConfigOverride
+    };
+
+    const buildDir = path.normalize(
+      `/path/to/${PluginBuildDir.BUILD_DIR_NAME}`
+    );
+
+    const promise = getNextPagesFromBuildDir(buildDir, pageConfig).then(
+      nextPages => {
+        expect(nextPages[0].serverlessFunctionOverrides).toEqual(
+          asteriskPageConfigOverride
+        );
+        expect(nextPages[1].serverlessFunctionOverrides).toEqual(
+          asteriskPageConfigOverride
+        );
+      }
+    );
+
+    mockedStream.emit("data", { path: path.join(buildDir, "index.js") });
+    mockedStream.emit("data", { path: path.join(buildDir, "about.js") });
+    mockedStream.emit("end");
+
+    return promise;
+  });
+
   it("should log pages found", () => {
     expect.assertions(1);
 

--- a/lib/getNextPagesFromBuildDir.js
+++ b/lib/getNextPagesFromBuildDir.js
@@ -54,7 +54,11 @@ module.exports = async (buildDir, pageConfig = {}, additionalExcludes = []) => {
     .filter(bf => !bf.endsWith(SOURCE_MAP_EXT))
     .map(normalisedFilePath => {
       const nextPage = new NextPage(normalisedFilePath);
-      nextPage.serverlessFunctionOverrides = pageConfig[nextPage.pageName];
+      nextPage.serverlessFunctionOverrides = Object.assign(
+        {},
+        pageConfig["*"],
+        pageConfig[nextPage.pageName]
+      );
 
       return nextPage;
     });


### PR DESCRIPTION
Needed a way to add config to all page functions so added a very simple way of doing so by allowing an asterisk `*` entry in pageConfig that is applied to all functions. The global config can itself be overridden by page-specific config.