### PR TITLE
Use pageId as identifier 

### DIFF
--- a/classes/NextPage.js
+++ b/classes/NextPage.js
@@ -51,15 +51,19 @@ class NextPage {
   }
 
   get functionName() {
-    if (this.pageName === "_error") {
+    if (this.pageId === "_error") {
       return "notFoundErrorPage";
     }
 
-    return this.pageName + "Page";
+    return (
+      this.pageId
+        .replace(new RegExp(path.posix.sep, "g"), "-")
+        .replace(/^-/, "") + "Page"
+    );
   }
 
   get pageRoute() {
-    switch (this.pageName) {
+    switch (this.pageId) {
       case "index":
         return "/";
       case "_error":

--- a/classes/NextPage.js
+++ b/classes/NextPage.js
@@ -58,7 +58,8 @@ class NextPage {
     return (
       this.pageId
         .replace(new RegExp(path.posix.sep, "g"), "-")
-        .replace(/^-/, "") + "Page"
+        .replace(/^-/, "")
+        .replace(/[^\w-]/g, "_") + "Page"
     );
   }
 

--- a/classes/__tests__/NextPage.test.js
+++ b/classes/__tests__/NextPage.test.js
@@ -57,6 +57,15 @@ describe("NextPage", () => {
       expect(page.functionName).toEqual("adminPage");
     });
 
+    it("replaces non-alphanumeric chars in pageFunctionName", () => {
+      const pagePath = `${PluginBuildDir.BUILD_DIR_NAME}/$home.js`;
+      const page = new NextPage(pagePath, {
+        serverlessFunctionOverrides: {},
+        routes: []
+      });
+      expect(page.functionName).toEqual("_homePage");
+    });
+
     it("returns pageId", () => {
       expect(page.pageId).toEqual("admin");
     });

--- a/classes/__tests__/NextPage.test.js
+++ b/classes/__tests__/NextPage.test.js
@@ -270,7 +270,9 @@ describe("NextPage", () => {
 
     describe("#serverlessFunction", () => {
       it("returns URI path matching subdirectories", () => {
-        const { events } = page.serverlessFunction.fridgesPage;
+        const { events } = page.serverlessFunction[
+          "categories-fridge-fridgesPage"
+        ];
 
         expect(events).toHaveLength(2);
 

--- a/classes/__tests__/NextPage.test.js
+++ b/classes/__tests__/NextPage.test.js
@@ -58,7 +58,7 @@ describe("NextPage", () => {
     });
 
     it("replaces non-alphanumeric chars in pageFunctionName", () => {
-      const pagePath = `${PluginBuildDir.BUILD_DIR_NAME}/$home.js`;
+      const pagePath = path.join(buildDir, "$home.js");
       const page = new NextPage(pagePath, {
         serverlessFunctionOverrides: {},
         routes: []

--- a/integration/__tests__/package.test.js
+++ b/integration/__tests__/package.test.js
@@ -71,7 +71,7 @@ describe.each`
             about: resources.AboutPageLambdaFunction,
             post: resources.PostPageLambdaFunction,
             blog: resources.BlogPageLambdaFunction,
-            fridges: resources.FridgesPageLambdaFunction
+            fridges: resources.CategoriesDashfridgeDashfridgesPageLambdaFunction
           };
         });
 

--- a/lib/__tests__/build.test.js
+++ b/lib/__tests__/build.test.js
@@ -218,8 +218,8 @@ describe("build", () => {
     return build.call(plugin).then(() => {
       expect(setFunctionNamesMock).toBeCalled();
       expect(Object.keys(plugin.serverless.service.functions)).toEqual([
-        "barPage",
-        "bazPage"
+        "foo-barPage",
+        "foo-bazPage"
       ]);
     });
   });

--- a/lib/__tests__/rewritePageHandlers.js
+++ b/lib/__tests__/rewritePageHandlers.js
@@ -32,10 +32,14 @@ describe("rewritePageHandlers", () => {
 
     it("should log", () => {
       expect(logger.log).toBeCalledWith(
-        expect.stringContaining("compat handler for page: home.js")
+        expect.stringContaining(
+          "compat handler for page: build/serverless/pages/home.js"
+        )
       );
       expect(logger.log).toBeCalledWith(
-        expect.stringContaining("compat handler for page: about.js")
+        expect.stringContaining(
+          "compat handler for page: build/serverless/pages/about.js"
+        )
       );
     });
 

--- a/lib/getNextPagesFromBuildDir.js
+++ b/lib/getNextPagesFromBuildDir.js
@@ -67,7 +67,7 @@ module.exports = async (buildDir, options = {}) => {
       nextPage.serverlessFunctionOverrides = Object.assign(
         {},
         pageConfig["*"],
-        pageConfig[nextPage.pageName]
+        pageConfig[nextPage.pageId]
       );
 
       return nextPage;

--- a/lib/rewritePageHandlers.js
+++ b/lib/rewritePageHandlers.js
@@ -12,7 +12,7 @@ const processJsHandler = async (nextPage, customHandler) => {
     customHandler
   );
 
-  logger.log(`Creating compat handler for page: ${nextPage.pageName}.js`);
+  logger.log(`Creating compat handler for page: ${nextPage.pageId}.js`);
 
   await writeFileAsync(nextPage.pageCompatPath, compatCodeContent);
 


### PR DESCRIPTION
In order to not cause conflicts between pages with same name in different folders.

ref https://github.com/danielcondemarin/serverless-nextjs-plugin/issues/67

We might have a few pageIds with `$` in the future so while I was at it, I added a normalisation for the function name in oder to not break CloudFormation-Ressource names.

PTAL: @danielcondemarin 