### PR TITLE
fix: parse non-alphanumeric characters in resourceName

### DIFF
--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -5,7 +5,9 @@ const getAssetsBucketName = require("./getAssetsBucketName");
 const logger = require("../utils/logger");
 const loadYml = require("../utils/yml/load");
 
-const normaliseString = str =>
+const capitaliseFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+
+const normaliseResourceName = str =>
   str.charAt(0).toUpperCase() + str.slice(1).replace(/[^0-9a-zA-Z]/g, "");
 
 const isSubPath = (parentDir, subPath) => {
@@ -21,7 +23,7 @@ const normaliseSrc = (staticDir, src) =>
     .relative(staticDir, src)
     .split(path.sep)
     .filter(s => s !== "." && s !== "..")
-    .map(normaliseString)
+    .map(capitaliseFirstLetter)
     .join("");
 
 const getStaticRouteProxyResources = async function(bucketName) {
@@ -56,6 +58,7 @@ const getStaticRouteProxyResources = async function(bucketName) {
 
       let resourceName = normaliseSrc(staticDir, src);
       resourceName = path.parse(resourceName).name;
+      resourceName = normaliseResourceName(resourceName);
 
       const resource = clone(baseResource);
 

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -7,6 +7,7 @@ const loadYml = require("../utils/yml/load");
 
 const capitaliseFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
 
+// removes non-alphanumeric characters to adhere to AWS naming requirements
 const normaliseResourceName = str => str.replace(/[^0-9a-zA-Z]/g, "");
 
 const isSubPath = (parentDir, subPath) => {

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -79,27 +79,36 @@ const addCustomStackResources = async function() {
   const bucketName = getAssetsBucketName.call(this);
 
   if (bucketName === null) {
-    return Promise.resolve();
+    return;
   }
 
-  let resources = await loadYml(
+  let assetsBucketResource = await loadYml(
     path.join(__dirname, "../resources/assets-bucket.yml")
   );
 
   logger.log(`Found bucket "${bucketName}"`);
-
-  resources.Resources.NextStaticAssetsS3Bucket.Properties.BucketName = bucketName;
-
-  merge(this.serverless.service.provider.coreCloudFormationTemplate, resources);
 
   const proxyResources = await getStaticRouteProxyResources.call(
     this,
     bucketName
   );
 
-  merge(resources, proxyResources);
+  assetsBucketResource.Resources.NextStaticAssetsS3Bucket.Properties.BucketName = bucketName;
 
-  this.serverless.service.resources = resources;
+  this.serverless.service.resources = this.serverless.service.resources || {
+    Resources: {}
+  };
+
+  merge(
+    this.serverless.service.provider.coreCloudFormationTemplate,
+    assetsBucketResource
+  );
+
+  merge(
+    this.serverless.service.resources,
+    assetsBucketResource,
+    proxyResources
+  );
 };
 
 module.exports = addCustomStackResources;

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -7,8 +7,7 @@ const loadYml = require("../utils/yml/load");
 
 const capitaliseFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
 
-const normaliseResourceName = str =>
-  str.charAt(0).toUpperCase() + str.slice(1).replace(/[^0-9a-zA-Z]/g, "");
+const normaliseResourceName = str => str.replace(/[^0-9a-zA-Z]/g, "");
 
 const isSubPath = (parentDir, subPath) => {
   const relative = path.relative(parentDir, subPath);

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -5,7 +5,11 @@ const getAssetsBucketName = require("./getAssetsBucketName");
 const logger = require("../utils/logger");
 const loadYml = require("../utils/yml/load");
 
-const capitaliseFirstLetter = str => str.charAt(0).toUpperCase() + str.slice(1);
+const normaliseString = str =>
+  str
+    .charAt(0)
+    .toUpperCase() + str.slice(1)
+    .replace(/[^0-9a-zA-Z]/g, '');
 
 const isSubPath = (parentDir, subPath) => {
   const relative = path.relative(parentDir, subPath);
@@ -20,7 +24,7 @@ const normaliseSrc = (staticDir, src) =>
     .relative(staticDir, src)
     .split(path.sep)
     .filter(s => s !== "." && s !== "..")
-    .map(capitaliseFirstLetter)
+    .map(normaliseString)
     .join("");
 
 const getStaticRouteProxyResources = async function(bucketName) {


### PR DESCRIPTION
Adding a route with unparsed non-alphanumeric characters (e.g. `favicon-32x32.png`) to `serverless.yml` would cause AWS to throw "Resource name is non alphanumeric" error.