### PR TITLE
CloudFront Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The plugin targets [Next 8 serverless mode](https://nextjs.org/blog/next-8/#serv
 - [Motivation](#motivation)
 - [Getting Started](#getting-started)
 - [Hosting static assets](#hosting-static-assets)
+- [Serving static assets](#serving-static-assets)
 - [Deploying](#deploying)
 - [Deploying a single page](#deploying-a-single-page)
 - [Overriding page configuration](#overriding-page-configuration)
@@ -116,8 +117,6 @@ custom:
     assetsBucketName: "your-bucket-name"
 ```
 
-With this approach you could have a CloudFront distribution in front of the bucket and use a custom domain in the assetPrefix.
-
 ## Serving static assets
 
 Static files can be served by [following the NextJs convention](https://github.com/zeit/next.js/#static-file-serving-eg-images) of using a `static` and `public` folder.
@@ -135,6 +134,23 @@ export default MyImage
 To serve static files from the root directory you can add a folder called public and reference those files from the root, e.g: /robots.txt.
 
 Note that for this to work, an S3 bucket needs to be provisioned as per [hosting-static-assets](#hosting-static-assets).
+
+**For production deployments, enabling CloudFront is recommended:**
+
+```yml
+# serverless.yml
+plugins:
+  - serverless-nextjs-plugin
+
+custom:
+  serverless-nextjs:
+    assetsBucketName: "your-bucket-name"
+    cloudFront: true
+```
+
+By doing this, a CloudFront distribution will be created in front of your next application to serve any static assets from S3 and the pages from Api Gateway.
+
+Note that deploying the stack for the first time will take considerably longer, as CloudFront takes time propagating the changes, typically 10 - 20mins.
 
 ## Deploying
 

--- a/packages/serverless-nextjs-plugin/README.md
+++ b/packages/serverless-nextjs-plugin/README.md
@@ -117,8 +117,6 @@ custom:
     assetsBucketName: "your-bucket-name"
 ```
 
-With this approach you could have a CloudFront distribution in front of the bucket and use a custom domain in the assetPrefix.
-
 ## Serving static assets
 
 Static files can be served by [following the NextJs convention](https://github.com/zeit/next.js/#static-file-serving-eg-images) of using a `static` and `public` folder.
@@ -136,6 +134,23 @@ export default MyImage
 To serve static files from the root directory you can add a folder called public and reference those files from the root, e.g: /robots.txt.
 
 Note that for this to work, an S3 bucket needs to be provisioned as per [hosting-static-assets](#hosting-static-assets).
+
+**For production deployments, enabling CloudFront is recommended:**
+
+```yml
+# serverless.yml
+plugins:
+  - serverless-nextjs-plugin
+
+custom:
+  serverless-nextjs:
+    assetsBucketName: "your-bucket-name"
+    cloudFront: true
+```
+
+By doing this, a CloudFront distribution will be created in front of your next application to serve any static assets from S3 and the pages from Api Gateway.
+
+Note that deploying the stack for the first time will take considerably longer, as CloudFront takes time propagating the changes, typically 10 - 20mins.
 
 ## Deploying
 

--- a/packages/serverless-nextjs-plugin/README.md
+++ b/packages/serverless-nextjs-plugin/README.md
@@ -10,13 +10,14 @@ A [serverless framework](https://serverless.com/) plugin to deploy nextjs apps.
 
 The plugin targets [Next 8 serverless mode](https://nextjs.org/blog/next-8/#serverless-nextjs)
 
-![demo](../../demo.gif)
+![demo](./demo.gif)
 
 ## Contents
 
 - [Motivation](#motivation)
 - [Getting Started](#getting-started)
 - [Hosting static assets](#hosting-static-assets)
+- [Serving static assets](#serving-static-assets)
 - [Deploying](#deploying)
 - [Deploying a single page](#deploying-a-single-page)
 - [Overriding page configuration](#overriding-page-configuration)
@@ -24,8 +25,8 @@ The plugin targets [Next 8 serverless mode](https://nextjs.org/blog/next-8/#serv
 - [Custom error page](#custom-error-page)
 - [Custom lambda handler](#custom-lambda-handler)
 - [All plugin configuration options](#all-plugin-configuration-options)
-- [Caveats](#caveats)
 - [Examples](#examples)
+- [Caveats](#caveats)
 - [Contributing](#contributing)
 
 ## Motivation
@@ -118,18 +119,23 @@ custom:
 
 With this approach you could have a CloudFront distribution in front of the bucket and use a custom domain in the assetPrefix.
 
-If you need the static assets available in the main domain of your application, you can use the `routes` configuration to proxy API Gateway requests to S3. For example, to host `/robots.txt`:
+## Serving static assets
 
-```yml
-custom:
-  serverless-nextjs:
-    staticDir: ./assets
-    routes:
-      - src: ./assets/robots.txt
-        path: robots.txt
+Static files can be served by [following the NextJs convention](https://github.com/zeit/next.js/#static-file-serving-eg-images) of using a `static` and `public` folder.
+
+From your code you can then reference those files with a `/static` URL:
+
+```
+function MyImage() {
+  return <img src="/static/my-image.png" alt="my image" />
+}
+
+export default MyImage
 ```
 
-Note that for this to work, an S3 bucket needs to be provisioned by using the `assetsBucketName` plugin config or `assetPrefix` in `next.config.js`.
+To serve static files from the root directory you can add a folder called public and reference those files from the root, e.g: /robots.txt.
+
+Note that for this to work, an S3 bucket needs to be provisioned as per [hosting-static-assets](#hosting-static-assets).
 
 ## Deploying
 
@@ -312,15 +318,13 @@ module.exports = page => {
 
 ## All plugin configuration options
 
-| Plugin config key | Default Value | Description                                                                                                                                                                                                                      |
-| ----------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| nextConfigDir     | ./            | Path to parent directory of `next.config.js`.                                                                                                                                                                                    |
-| assetsBucketName  | \<empty\>     | Creates an S3 bucket with the name provided. The bucket will be used for uploading next static assets.                                                                                                                           |
-| staticDir         | \<empty\>     | Directory with static assets to be uploaded to S3, typically a directory named `static`, but it can be any other name. Requires a bucket provided via the `assetPrefix` described above or the `assetsBucketName` plugin config. |
-| routes            | []            | Array of custom routes for the next pages or static assets.                                                                                                                                                                      |
-| customHandler     | \<empty\>     | Path to your own lambda handler.                                                                                                                                                                                                 |
-| uploadBuildAssets | true          | In the unlikely event that you only want to upload `static` or `public` dirs, set this to `false`.                                                                                                                               |
-|  |
+| Plugin config key | Default Value | Description                                                                                            |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
+| nextConfigDir     | ./            | Path to parent directory of `next.config.js`.                                                          |
+| assetsBucketName  | \<empty\>     | Creates an S3 bucket with the name provided. The bucket will be used for uploading next static assets. |
+| routes            | []            | Array of custom routes for the next pages.                                                             |
+| customHandler     | \<empty\>     | Path to your own lambda handler.                                                                       |
+| uploadBuildAssets | true          | In the unlikely event that you only want to upload `static` or `public` dirs, set this to `false`.     |
 
 ## Caveats
 

--- a/packages/serverless-nextjs-plugin/index.js
+++ b/packages/serverless-nextjs-plugin/index.js
@@ -51,7 +51,8 @@ class ServerlessNextJsPlugin {
     const defaults = {
       routes: [],
       nextConfigDir: "./",
-      uploadBuildAssets: true
+      uploadBuildAssets: true,
+      cloudFront: false
     };
 
     const userConfig = this.serverless.service.custom["serverless-nextjs"][

--- a/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
@@ -256,6 +256,21 @@ describe("addCustomStackResources", () => {
       );
     });
 
+    it("sets up Api Gateway origin", () => {
+      const {
+        Resources: { NextjsCloudFront }
+      } = resources;
+
+      const apiGatewayOrigin = NextjsCloudFront.Properties.DistributionConfig.Origins.find(
+        o => o.Id === "ApiGatewayOrigin"
+      );
+
+      expect(apiGatewayOrigin.OriginPath).toEqual("/test");
+      expect(apiGatewayOrigin.DomainName["Fn::Join"][1][1]).toEqual(
+        ".execute-api.us-east-1.amazonaws.com"
+      );
+    });
+
     describe("when public folder exists", () => {
       it("adds cache behaviours for public files", () => {
         expect.assertions(4);

--- a/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
@@ -195,6 +195,9 @@ describe("addCustomStackResources", () => {
   });
 
   describe("when cloudfront is enabled and S3 bucket is configured", () => {
+    const findOrigin = (distribution, originId) =>
+      distribution.Origins.find(o => o.Id === originId);
+
     let assetsBucketName = "foo.bar";
     let resources;
 
@@ -233,8 +236,9 @@ describe("addCustomStackResources", () => {
         Resources: { NextjsCloudFront }
       } = resources;
 
-      const staticOrigin = NextjsCloudFront.Properties.DistributionConfig.Origins.find(
-        o => o.Id === "S3StaticOrigin"
+      const staticOrigin = findOrigin(
+        NextjsCloudFront.Properties.DistributionConfig,
+        "S3StaticOrigin"
       );
 
       expect(staticOrigin.DomainName).toEqual(
@@ -247,8 +251,9 @@ describe("addCustomStackResources", () => {
         Resources: { NextjsCloudFront }
       } = resources;
 
-      const publicOrigin = NextjsCloudFront.Properties.DistributionConfig.Origins.find(
-        o => o.Id === "S3PublicOrigin"
+      const publicOrigin = findOrigin(
+        NextjsCloudFront.Properties.DistributionConfig,
+        "S3PublicOrigin"
       );
 
       expect(publicOrigin.DomainName).toEqual(
@@ -261,8 +266,9 @@ describe("addCustomStackResources", () => {
         Resources: { NextjsCloudFront }
       } = resources;
 
-      const apiGatewayOrigin = NextjsCloudFront.Properties.DistributionConfig.Origins.find(
-        o => o.Id === "ApiGatewayOrigin"
+      const apiGatewayOrigin = findOrigin(
+        NextjsCloudFront.Properties.DistributionConfig,
+        "ApiGatewayOrigin"
       );
 
       expect(apiGatewayOrigin.OriginPath).toEqual("/test");

--- a/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
@@ -231,14 +231,14 @@ describe("addCustomStackResources", () => {
       expect(NextjsCloudFront).toBeDefined();
     });
 
-    it("sets up S3 origin for /static directory", () => {
+    it("sets up S3 origin", () => {
       const {
         Resources: { NextjsCloudFront }
       } = resources;
 
       const staticOrigin = findOrigin(
         NextjsCloudFront.Properties.DistributionConfig,
-        "S3StaticOrigin"
+        "S3Origin"
       );
 
       expect(staticOrigin.DomainName).toEqual(
@@ -311,9 +311,9 @@ describe("addCustomStackResources", () => {
             CacheBehaviors
           } = NextjsCloudFront.Properties.DistributionConfig;
 
-          expect(CacheBehaviors).toHaveLength(3); // behavior for /static origin and 2 other behaviours for robots and manifest
-          expect(CacheBehaviors[1].PathPattern).toEqual("robots.txt");
-          expect(CacheBehaviors[2].PathPattern).toEqual("manifest.json");
+          expect(CacheBehaviors).toHaveLength(4); // behavior for static/*, _next/* origins and 2 other behaviours for robots and manifest
+          expect(CacheBehaviors[2].PathPattern).toEqual("robots.txt");
+          expect(CacheBehaviors[3].PathPattern).toEqual("manifest.json");
         });
       });
     });

--- a/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/addCustomStackResources.test.js
@@ -11,189 +11,194 @@ jest.mock("../getAssetsBucketName");
 jest.mock("../../utils/logger");
 
 describe("addCustomStackResources", () => {
-  const bucketName = "bucket-123";
-  const bucketUrl = `https://s3.amazonaws.com/${bucketName}`;
-
   beforeEach(() => {
     fse.pathExists = jest.fn();
     fse.readdir = jest.fn();
 
     fse.pathExists.mockResolvedValue(false);
-
-    getAssetsBucketName.mockReturnValueOnce(bucketName);
   });
 
-  it("adds S3 bucket to resources", () => {
-    expect.assertions(3);
+  describe("When cloudfront is disabled and S3 bucket is configured", () => {
+    const bucketName = "bucket-123";
+    const bucketUrl = `https://s3.amazonaws.com/${bucketName}`;
 
-    const coreCfTemplate = {
-      Resources: {
-        existingResource: "existingValue"
-      }
-    };
+    beforeEach(() => {
+      getAssetsBucketName.mockReturnValueOnce(bucketName);
+    });
 
-    const plugin = new ServerlessPluginBuilder().build();
+    it("adds S3 bucket to resources", () => {
+      expect.assertions(3);
 
-    plugin.serverless.service.provider.coreCloudFormationTemplate = clone(
-      coreCfTemplate
-    );
+      const coreCfTemplate = {
+        Resources: {
+          existingResource: "existingValue"
+        }
+      };
 
-    return addCustomStackResources.call(plugin).then(() => {
-      expect(logger.log).toBeCalledWith(
-        expect.stringContaining(`Found bucket "${bucketName}"`)
+      const plugin = new ServerlessPluginBuilder().build();
+
+      plugin.serverless.service.provider.coreCloudFormationTemplate = clone(
+        coreCfTemplate
       );
-      const { service } = plugin.serverless;
-      const { NextStaticAssetsS3Bucket } = service.resources.Resources;
 
-      expect(NextStaticAssetsS3Bucket.Properties.BucketName).toEqual(
-        bucketName
+      return addCustomStackResources.call(plugin).then(() => {
+        expect(logger.log).toBeCalledWith(
+          expect.stringContaining(`Found bucket "${bucketName}"`)
+        );
+        const { service } = plugin.serverless;
+        const { NextStaticAssetsS3Bucket } = service.resources.Resources;
+
+        expect(NextStaticAssetsS3Bucket.Properties.BucketName).toEqual(
+          bucketName
+        );
+        expect(
+          service.provider.coreCloudFormationTemplate.Resources.existingResource
+        ).toEqual("existingValue");
+      });
+    });
+
+    it("adds proxy routes for static directory", () => {
+      expect.assertions(2);
+
+      const plugin = new ServerlessPluginBuilder().build();
+
+      const staticDir = path.join(
+        plugin.getPluginConfigValue("nextConfigDir"),
+        "static"
       );
-      expect(
-        service.provider.coreCloudFormationTemplate.Resources.existingResource
-      ).toEqual("existingValue");
+
+      when(fse.pathExists)
+        .calledWith(staticDir)
+        .mockResolvedValue(true);
+
+      return addCustomStackResources.call(plugin).then(() => {
+        const resources = plugin.serverless.service.resources.Resources;
+        expect(Object.keys(resources)).toEqual(
+          expect.arrayContaining([
+            "StaticAssetsProxyParentResource",
+            "StaticAssetsProxyResource",
+            "StaticAssetsProxyMethod"
+          ])
+        );
+        expect(
+          resources.StaticAssetsProxyMethod.Properties.Integration.Uri
+        ).toEqual("https://s3.amazonaws.com/bucket-123/static/{proxy}");
+      });
+    });
+
+    it("adds proxy routes for nextjs assets", () => {
+      expect.assertions(2);
+
+      const plugin = new ServerlessPluginBuilder().build();
+
+      return addCustomStackResources.call(plugin).then(() => {
+        const resources = plugin.serverless.service.resources.Resources;
+        expect(Object.keys(resources)).toEqual(
+          expect.arrayContaining([
+            "NextStaticAssetsProxyParentResource",
+            "NextStaticAssetsProxyResource",
+            "NextStaticAssetsProxyMethod"
+          ])
+        );
+        expect(
+          resources.NextStaticAssetsProxyMethod.Properties.Integration.Uri
+        ).toEqual("https://s3.amazonaws.com/bucket-123/_next/{proxy}");
+      });
+    });
+
+    it("adds proxy route to each file in the public folder", () => {
+      expect.assertions(8);
+
+      const plugin = new ServerlessPluginBuilder().build();
+      const publicDir = path.join(
+        plugin.getPluginConfigValue("nextConfigDir"),
+        "public"
+      );
+
+      when(fse.pathExists)
+        .calledWith(publicDir)
+        .mockResolvedValue(true);
+
+      when(fse.readdir)
+        .calledWith(publicDir)
+        .mockResolvedValue(["robots.txt", "manifest.json"]);
+
+      return addCustomStackResources.call(plugin).then(() => {
+        const {
+          RobotsProxyMethod,
+          RobotsProxyResource,
+          ManifestProxyMethod,
+          ManifestProxyResource
+        } = plugin.serverless.service.resources.Resources;
+
+        expect(RobotsProxyMethod.Properties.Integration.Uri).toEqual(
+          `${bucketUrl}/public/robots.txt`
+        );
+        expect(RobotsProxyMethod.Properties.ResourceId.Ref).toEqual(
+          "RobotsProxyResource"
+        );
+        expect(RobotsProxyResource.Properties.PathPart).toEqual("robots.txt");
+        expect(logger.log).toBeCalledWith(
+          `Proxying robots.txt -> ${bucketUrl}/public/robots.txt`
+        );
+
+        expect(ManifestProxyMethod.Properties.Integration.Uri).toEqual(
+          `${bucketUrl}/public/manifest.json`
+        );
+        expect(ManifestProxyMethod.Properties.ResourceId.Ref).toEqual(
+          "ManifestProxyResource"
+        );
+        expect(ManifestProxyResource.Properties.PathPart).toEqual(
+          `manifest.json`
+        );
+        expect(logger.log).toBeCalledWith(
+          `Proxying manifest.json -> ${bucketUrl}/public/manifest.json`
+        );
+      });
+    });
+
+    it("adds proxy route to resources with correct bucket url for the region", () => {
+      expect.assertions(2);
+
+      const euWestRegion = "eu-west-1";
+      const bucketUrlIreland = `https://s3-${euWestRegion}.amazonaws.com/${bucketName}`;
+      const getRegion = jest.fn().mockReturnValueOnce(euWestRegion);
+
+      const plugin = new ServerlessPluginBuilder().build();
+
+      const publicDir = path.join(
+        plugin.getPluginConfigValue("nextConfigDir"),
+        "public"
+      );
+
+      when(fse.pathExists)
+        .calledWith(publicDir)
+        .mockResolvedValue(true);
+
+      when(fse.readdir)
+        .calledWith(publicDir)
+        .mockResolvedValue(["robots.txt"]);
+
+      plugin.provider.getRegion = getRegion;
+
+      return addCustomStackResources.call(plugin).then(() => {
+        const {
+          RobotsProxyMethod
+        } = plugin.serverless.service.resources.Resources;
+
+        expect(getRegion).toBeCalled();
+        expect(RobotsProxyMethod.Properties.Integration.Uri).toEqual(
+          `${bucketUrlIreland}/public/robots.txt`
+        );
+      });
     });
   });
 
-  it("adds proxy routes for static directory", () => {
-    expect.assertions(2);
+  describe("when cloudfront is enabled and S3 bucket is configured", () => {
+    let assetsBucketName = "foo.bar";
+    let resources;
 
-    const plugin = new ServerlessPluginBuilder().build();
-
-    const staticDir = path.join(
-      plugin.getPluginConfigValue("nextConfigDir"),
-      "static"
-    );
-
-    when(fse.pathExists)
-      .calledWith(staticDir)
-      .mockResolvedValue(true);
-
-    return addCustomStackResources.call(plugin).then(() => {
-      const resources = plugin.serverless.service.resources.Resources;
-      expect(Object.keys(resources)).toEqual(
-        expect.arrayContaining([
-          "StaticAssetsProxyParentResource",
-          "StaticAssetsProxyResource",
-          "StaticAssetsProxyMethod"
-        ])
-      );
-      expect(
-        resources.StaticAssetsProxyMethod.Properties.Integration.Uri
-      ).toEqual("https://s3.amazonaws.com/bucket-123/static/{proxy}");
-    });
-  });
-
-  it("adds proxy routes for nextjs assets", () => {
-    expect.assertions(2);
-
-    const plugin = new ServerlessPluginBuilder().build();
-
-    return addCustomStackResources.call(plugin).then(() => {
-      const resources = plugin.serverless.service.resources.Resources;
-      expect(Object.keys(resources)).toEqual(
-        expect.arrayContaining([
-          "NextStaticAssetsProxyParentResource",
-          "NextStaticAssetsProxyResource",
-          "NextStaticAssetsProxyMethod"
-        ])
-      );
-      expect(
-        resources.NextStaticAssetsProxyMethod.Properties.Integration.Uri
-      ).toEqual("https://s3.amazonaws.com/bucket-123/_next/{proxy}");
-    });
-  });
-
-  it("adds proxy route to each file in the public folder", () => {
-    expect.assertions(8);
-
-    const plugin = new ServerlessPluginBuilder().build();
-    const publicDir = path.join(
-      plugin.getPluginConfigValue("nextConfigDir"),
-      "public"
-    );
-
-    when(fse.pathExists)
-      .calledWith(publicDir)
-      .mockResolvedValue(true);
-
-    when(fse.readdir)
-      .calledWith(publicDir)
-      .mockResolvedValue(["robots.txt", "manifest.json"]);
-
-    return addCustomStackResources.call(plugin).then(() => {
-      const {
-        RobotsProxyMethod,
-        RobotsProxyResource,
-        ManifestProxyMethod,
-        ManifestProxyResource
-      } = plugin.serverless.service.resources.Resources;
-
-      expect(RobotsProxyMethod.Properties.Integration.Uri).toEqual(
-        `${bucketUrl}/public/robots.txt`
-      );
-      expect(RobotsProxyMethod.Properties.ResourceId.Ref).toEqual(
-        "RobotsProxyResource"
-      );
-      expect(RobotsProxyResource.Properties.PathPart).toEqual("robots.txt");
-      expect(logger.log).toBeCalledWith(
-        `Proxying robots.txt -> ${bucketUrl}/public/robots.txt`
-      );
-
-      expect(ManifestProxyMethod.Properties.Integration.Uri).toEqual(
-        `${bucketUrl}/public/manifest.json`
-      );
-      expect(ManifestProxyMethod.Properties.ResourceId.Ref).toEqual(
-        "ManifestProxyResource"
-      );
-      expect(ManifestProxyResource.Properties.PathPart).toEqual(
-        `manifest.json`
-      );
-      expect(logger.log).toBeCalledWith(
-        `Proxying manifest.json -> ${bucketUrl}/public/manifest.json`
-      );
-    });
-  });
-
-  it("adds proxy route to resources with correct bucket url for the region", () => {
-    expect.assertions(2);
-
-    const euWestRegion = "eu-west-1";
-    const bucketUrlIreland = `https://s3-${euWestRegion}.amazonaws.com/${bucketName}`;
-    const getRegion = jest.fn().mockReturnValueOnce(euWestRegion);
-
-    const plugin = new ServerlessPluginBuilder().build();
-
-    const publicDir = path.join(
-      plugin.getPluginConfigValue("nextConfigDir"),
-      "public"
-    );
-
-    when(fse.pathExists)
-      .calledWith(publicDir)
-      .mockResolvedValue(true);
-
-    when(fse.readdir)
-      .calledWith(publicDir)
-      .mockResolvedValue(["robots.txt"]);
-
-    plugin.provider.getRegion = getRegion;
-
-    return addCustomStackResources.call(plugin).then(() => {
-      const {
-        RobotsProxyMethod
-      } = plugin.serverless.service.resources.Resources;
-
-      expect(getRegion).toBeCalled();
-      expect(RobotsProxyMethod.Properties.Integration.Uri).toEqual(
-        `${bucketUrlIreland}/public/robots.txt`
-      );
-    });
-  });
-
-  describe.skip("when cloudfront is enabled", () => {
-    it("adds distribution", () => {
-      expect.assertions(1);
-
+    beforeEach(() => {
       const plugin = new ServerlessPluginBuilder()
         .withPluginConfig({
           cloudFront: true
@@ -205,24 +210,101 @@ describe("addCustomStackResources", () => {
         "public"
       );
 
+      getAssetsBucketName.mockReturnValue(assetsBucketName);
+
       when(fse.pathExists)
         .calledWith(publicDir)
         .mockResolvedValue(false);
 
       return addCustomStackResources.call(plugin).then(() => {
-        const { Resources } = plugin.serverless.service.resources;
-        expect(Object.keys(Resources)).toHaveLength(2); // S3 bucket and CloudFront distribution
+        resources = plugin.serverless.service.resources;
+      });
+    });
+
+    it("adds distribution", () => {
+      const { Resources } = resources;
+      expect(Object.keys(Resources)).toHaveLength(2); // S3 bucket and CloudFront distribution
+      const { NextjsCloudFront } = Resources;
+      expect(NextjsCloudFront).toBeDefined();
+    });
+
+    it("sets up S3 origin for /static directory", () => {
+      const {
+        Resources: { NextjsCloudFront }
+      } = resources;
+
+      const staticOrigin = NextjsCloudFront.Properties.DistributionConfig.Origins.find(
+        o => o.Id === "S3StaticOrigin"
+      );
+
+      expect(staticOrigin.DomainName).toEqual(
+        `${assetsBucketName}.s3.amazonaws.com`
+      );
+    });
+
+    it("sets up S3 origin for /public directory", () => {
+      const {
+        Resources: { NextjsCloudFront }
+      } = resources;
+
+      const publicOrigin = NextjsCloudFront.Properties.DistributionConfig.Origins.find(
+        o => o.Id === "S3PublicOrigin"
+      );
+
+      expect(publicOrigin.DomainName).toEqual(
+        `${assetsBucketName}.s3.amazonaws.com`
+      );
+    });
+
+    describe("when public folder exists", () => {
+      it("adds cache behaviours for public files", () => {
+        expect.assertions(4);
+
+        const plugin = new ServerlessPluginBuilder()
+          .withPluginConfig({
+            cloudFront: true
+          })
+          .build();
+
+        const publicDir = path.join(
+          plugin.getPluginConfigValue("nextConfigDir"),
+          "public"
+        );
+
+        when(fse.pathExists)
+          .calledWith(publicDir)
+          .mockResolvedValue(true);
+
+        when(fse.readdir)
+          .calledWith(publicDir)
+          .mockResolvedValue(["robots.txt", "manifest.json"]);
+
+        return addCustomStackResources.call(plugin).then(() => {
+          const {
+            NextjsCloudFront
+          } = plugin.serverless.service.resources.Resources;
+
+          expect(NextjsCloudFront).toBeDefined();
+
+          const {
+            CacheBehaviors
+          } = NextjsCloudFront.Properties.DistributionConfig;
+
+          expect(CacheBehaviors).toHaveLength(3); // behavior for /static origin and 2 other behaviours for robots and manifest
+          expect(CacheBehaviors[1].PathPattern).toEqual("robots.txt");
+          expect(CacheBehaviors[2].PathPattern).toEqual("manifest.json");
+        });
       });
     });
   });
 
-  describe("When no bucket available", () => {
+  describe("When no bucket is configured", () => {
     beforeEach(() => {
       getAssetsBucketName.mockReset();
       getAssetsBucketName.mockReturnValue(null);
     });
 
-    it("doesn't add S3 bucket to resources", () => {
+    it("doesn't add any custom resources", () => {
       expect.assertions(3);
 
       const plugin = new ServerlessPluginBuilder().build();

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -34,6 +34,7 @@ const normaliseFilePathForCloudFrontResourceKey = filePath =>
 const cacheBehaviour = fileName => ({
   AllowedMethods: ["GET", "HEAD", "OPTIONS"],
   TargetOriginId: "S3PublicOrigin",
+  Compress: true,
   ForwardedValues: {
     QueryString: "false",
     Cookies: { Forward: "none" }

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -153,6 +153,8 @@ const getPublicRouteProxyResources = async function({
 
 const addCustomStackResources = async function() {
   const region = this.provider.getRegion();
+  const stage = this.provider.getStage();
+
   const bucketName = getAssetsBucketName.call(this);
 
   if (bucketName === null) {
@@ -197,6 +199,12 @@ const addCustomStackResources = async function() {
 
     const findOrigin = originId =>
       DistributionConfig.Origins.find(o => o.Id === originId);
+
+    const apiGatewayOrigin = findOrigin("ApiGatewayOrigin");
+    apiGatewayOrigin.OriginPath = `/${stage}`;
+    apiGatewayOrigin.DomainName[
+      "Fn::Join"
+    ][1][1] = `.execute-api.${region}.amazonaws.com`;
 
     const publicOrigin = findOrigin("S3PublicOrigin");
     const staticOrigin = findOrigin("S3StaticOrigin");

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -209,8 +209,10 @@ const addCustomStackResources = async function() {
     const publicOrigin = findOrigin("S3PublicOrigin");
     const staticOrigin = findOrigin("S3StaticOrigin");
 
-    publicOrigin.DomainName = `${bucketName}.s3.amazonaws.com`;
-    staticOrigin.DomainName = `${bucketName}.s3.amazonaws.com`;
+    const bucketDomainName = `${bucketName}.s3.amazonaws.com`;
+
+    publicOrigin.DomainName = bucketDomainName;
+    staticOrigin.DomainName = bucketDomainName;
 
     const [publicDirExists, publicDirFiles] = await dirInfo(
       path.join(this.nextConfigDir, "public")

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -38,7 +38,7 @@ const cacheBehaviour = fileName => ({
     QueryString: "false",
     Cookies: { Forward: "none" }
   },
-  ViewerProtocolPolicy: "allow-all",
+  ViewerProtocolPolicy: "https-only",
   MinTTL: "50",
   PathPattern: path.basename(fileName)
 });
@@ -207,7 +207,7 @@ const addCustomStackResources = async function() {
     ][1][1] = `.execute-api.${region}.amazonaws.com`;
 
     const publicOrigin = findOrigin("S3PublicOrigin");
-    const staticOrigin = findOrigin("S3StaticOrigin");
+    const staticOrigin = findOrigin("S3Origin");
 
     const bucketDomainName = `${bucketName}.s3.amazonaws.com`;
 

--- a/packages/serverless-nextjs-plugin/lib/checkForChanges.js
+++ b/packages/serverless-nextjs-plugin/lib/checkForChanges.js
@@ -2,6 +2,7 @@ const getAssetsBucketName = require("./getAssetsBucketName");
 
 module.exports = function() {
   const bucketName = getAssetsBucketName.call(this);
+
   return this.provider
     .request("S3", "listObjectsV2", {
       Bucket: bucketName,

--- a/packages/serverless-nextjs-plugin/resources/cloudfront.yml
+++ b/packages/serverless-nextjs-plugin/resources/cloudfront.yml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Origins:
+          - DomainName: danielcondemarinbucket.s3.amazonaws.com
+            Id: S3StaticOrigin
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+          - DomainName: nbw1qo4fgh.execute-api.us-east-1.amazonaws.com
+            Id: ApiGatewayOrigin
+            OriginPath: /dev
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+        Enabled: "true"
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          TargetOriginId: ApiGatewayOrigin
+          ForwardedValues:
+            QueryString: "true"
+            Cookies:
+              Forward: all
+          ViewerProtocolPolicy: allow-all
+        CacheBehaviors:
+          - AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            TargetOriginId: S3StaticOrigin
+            ForwardedValues:
+              QueryString: "false"
+              Cookies:
+                Forward: none
+            ViewerProtocolPolicy: allow-all
+            MinTTL: "50"
+            PathPattern: static/
+        PriceClass: PriceClass_All

--- a/packages/serverless-nextjs-plugin/resources/cloudfront.yml
+++ b/packages/serverless-nextjs-plugin/resources/cloudfront.yml
@@ -1,15 +1,24 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  myDistribution:
+  NextjsCloudFront:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Origins:
-          - DomainName: danielcondemarinbucket.s3.amazonaws.com
+          - DomainName: TO_BE_REPLACED
             Id: S3StaticOrigin
             S3OriginConfig:
               OriginAccessIdentity: ""
-          - DomainName: nbw1qo4fgh.execute-api.us-east-1.amazonaws.com
+          - DomainName: TO_BE_REPLACED
+            Id: S3PublicOrigin
+            OriginPath: /public
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+          - DomainName:
+              Fn::Join:
+                - ""
+                - - Ref: ApiGatewayRestApi
+                  - ".execute-api.us-east-1.amazonaws.com"
             Id: ApiGatewayOrigin
             OriginPath: /dev
             CustomOriginConfig:

--- a/packages/serverless-nextjs-plugin/resources/cloudfront.yml
+++ b/packages/serverless-nextjs-plugin/resources/cloudfront.yml
@@ -31,6 +31,7 @@ Resources:
             - HEAD
             - OPTIONS
           TargetOriginId: ApiGatewayOrigin
+          Compress: "true"
           ForwardedValues:
             QueryString: "true"
             Cookies:
@@ -42,6 +43,7 @@ Resources:
               - HEAD
               - OPTIONS
             TargetOriginId: S3Origin
+            Compress: "true"
             ForwardedValues:
               QueryString: "false"
               Cookies:
@@ -54,6 +56,7 @@ Resources:
               - HEAD
               - OPTIONS
             TargetOriginId: S3Origin
+            Compress: "true"
             ForwardedValues:
               QueryString: "false"
               Cookies:

--- a/packages/serverless-nextjs-plugin/resources/cloudfront.yml
+++ b/packages/serverless-nextjs-plugin/resources/cloudfront.yml
@@ -6,7 +6,7 @@ Resources:
       DistributionConfig:
         Origins:
           - DomainName: TO_BE_REPLACED
-            Id: S3StaticOrigin
+            Id: S3Origin
             S3OriginConfig:
               OriginAccessIdentity: ""
           - DomainName: TO_BE_REPLACED
@@ -35,18 +35,30 @@ Resources:
             QueryString: "true"
             Cookies:
               Forward: all
-          ViewerProtocolPolicy: allow-all
+          ViewerProtocolPolicy: https-only
         CacheBehaviors:
           - AllowedMethods:
               - GET
               - HEAD
               - OPTIONS
-            TargetOriginId: S3StaticOrigin
+            TargetOriginId: S3Origin
             ForwardedValues:
               QueryString: "false"
               Cookies:
                 Forward: none
-            ViewerProtocolPolicy: allow-all
+            ViewerProtocolPolicy: https-only
             MinTTL: "50"
-            PathPattern: static/
-        PriceClass: PriceClass_All
+            PathPattern: static/*
+          - AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+            TargetOriginId: S3Origin
+            ForwardedValues:
+              QueryString: "false"
+              Cookies:
+                Forward: none
+            ViewerProtocolPolicy: https-only
+            MinTTL: "50"
+            PathPattern: _next/*
+        PriceClass: PriceClass_100

--- a/packages/serverless-nextjs-plugin/resources/cloudfront.yml
+++ b/packages/serverless-nextjs-plugin/resources/cloudfront.yml
@@ -18,9 +18,9 @@ Resources:
               Fn::Join:
                 - ""
                 - - Ref: ApiGatewayRestApi
-                  - ".execute-api.us-east-1.amazonaws.com"
+                  - TO_BE_REPLACED
             Id: ApiGatewayOrigin
-            OriginPath: /dev
+            OriginPath: TO_BE_REPLACED
             CustomOriginConfig:
               HTTPSPort: 443
               OriginProtocolPolicy: https-only

--- a/packages/serverless-nextjs-plugin/utils/test/ServerlessPluginBuilder.js
+++ b/packages/serverless-nextjs-plugin/utils/test/ServerlessPluginBuilder.js
@@ -9,7 +9,11 @@ class ServerlessPluginBuilder {
       },
       getPlugins: () => {},
       getProvider: () => {
-        return { request: () => {}, getRegion: () => "us-east-1" };
+        return {
+          request: () => {},
+          getRegion: () => "us-east-1",
+          getStage: () => "test"
+        };
       },
       pluginManager: {
         run: () => {}


### PR DESCRIPTION
## CloudFront Support


### Motivation

Currently, API Gateway is being used as a proxy to S3 to serve static assets from `/static` and `/public` directories. Whilst this works, is not the best solution as API Gateway is not as cost effective as CloudFront, nor is designed to be used as a CDN.
Also CloudFront comes with features such as compression, logging, domains, certificates etc. 

### Proposal

```yml
custom:
  serverless-nextjs:
    assetsBucketName: cloudfront.isawesome
    cloudFront: true
```

When `cloudFront` flag is set to true, a CloudFront distribution is created with API Gateway and S3 as origins. `_next` build assets and `static/` or `public/` folder assets are served from the S3 origin. Page requests, such as `/blog/:post` are served from the API Gateway origin.  

This article was used as a reference for implementation:
https://aws.amazon.com/premiumsupport/knowledge-center/api-gateway-cloudfront-distribution/
