### PR TITLE
Feature: Add option to disable bucket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,9 @@ module.exports = page => {
 | cloudFront        | `bool` \| `object` | false         | Set to `true` to create a cloud front distribution in front of your nextjs application. Also can be set to an `object` if you need to override CloudFront configuration, see [serving static assets](#serving-static-assets). |
 | routes            | `[]object`         | []            | Array of custom routes for the next pages.                                                                                                                                                                                    |
 | customHandler     | `string`           | \<empty\>     | Path to your own lambda handler.                                                                                                                                                                                              |
-| uploadBuildAssets | `bool`             | true          | In the unlikely event that you only want to upload `static` or `public` dirs, set this to `false`.                                                                                                                            |
+| uploadBuildAssets | `bool`             | true          | In the unlikely event that you only want to upload `static` or `public` dirs, set this to `false`.
+
+| createAssetBucket | `bool`             | true          | In the unlikely event that you don't want the plugin to create the S3 asset bucket, set this to `false`.
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -352,9 +352,9 @@ module.exports = page => {
 | cloudFront        | `bool` \| `object` | false         | Set to `true` to create a cloud front distribution in front of your nextjs application. Also can be set to an `object` if you need to override CloudFront configuration, see [serving static assets](#serving-static-assets). |
 | routes            | `[]object`         | []            | Array of custom routes for the next pages.                                                                                                                                                                                    |
 | customHandler     | `string`           | \<empty\>     | Path to your own lambda handler.                                                                                                                                                                                              |
-| uploadBuildAssets | `bool`             | true          | In the unlikely event that you only want to upload `static` or `public` dirs, set this to `false`.
+| uploadBuildAssets | `bool`             | true          | In the unlikely event that you only want to upload `static` or `public` dirs, set this to `false`.                                                                                                                            |
 
-| createAssetBucket | `bool`             | true          | In the unlikely event that you don't want the plugin to create the S3 asset bucket, set this to `false`.
+| createAssetBucket | `bool` | true | In the unlikely event that you don't want the plugin to create the S3 asset bucket, set this to `false`.
 
 ## Caveats
 

--- a/packages/serverless-nextjs-plugin/index.js
+++ b/packages/serverless-nextjs-plugin/index.js
@@ -52,7 +52,8 @@ class ServerlessNextJsPlugin {
       routes: [],
       nextConfigDir: "./",
       uploadBuildAssets: true,
-      cloudFront: false
+      cloudFront: false,
+      createAssetBucket: true,
     };
 
     const userConfig = this.serverless.service.custom["serverless-nextjs"][

--- a/packages/serverless-nextjs-plugin/index.js
+++ b/packages/serverless-nextjs-plugin/index.js
@@ -53,7 +53,7 @@ class ServerlessNextJsPlugin {
       nextConfigDir: "./",
       uploadBuildAssets: true,
       cloudFront: false,
-      createAssetBucket: true,
+      createAssetBucket: true
     };
 
     const userConfig = this.serverless.service.custom["serverless-nextjs"][

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -166,15 +166,15 @@ const addCustomStackResources = async function() {
 
   // see https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
   const bucketBaseUrl =
-  region === "us-east-1"
-    ? "https://s3.amazonaws.com"
-    : `https://s3-${region}.amazonaws.com`;
+    region === "us-east-1"
+      ? "https://s3.amazonaws.com"
+      : `https://s3-${region}.amazonaws.com`;
 
   const resourceConfiguration = { bucketName, bucketBaseUrl };
   let assetsBucketResource = {};
 
   const createAssetBucket = this.getPluginConfigValue("createAssetBucket");
-  
+
   if (createAssetBucket) {
     assetsBucketResource = await loadYml(
       path.join(__dirname, "../resources/assets-bucket.yml")

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -158,7 +158,7 @@ const addCustomStackResources = async function() {
 
   const bucketName = getAssetsBucketName.call(this);
 
-  if (bucketName === null) {
+  if (!bucketName) {
     return;
   }
 

--- a/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
+++ b/packages/serverless-nextjs-plugin/lib/addCustomStackResources.js
@@ -166,26 +166,31 @@ const addCustomStackResources = async function() {
 
   // see https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
   const bucketBaseUrl =
-    region === "us-east-1"
-      ? "https://s3.amazonaws.com"
-      : `https://s3-${region}.amazonaws.com`;
+  region === "us-east-1"
+    ? "https://s3.amazonaws.com"
+    : `https://s3-${region}.amazonaws.com`;
 
   const resourceConfiguration = { bucketName, bucketBaseUrl };
+  let assetsBucketResource = {};
 
-  let assetsBucketResource = await loadYml(
-    path.join(__dirname, "../resources/assets-bucket.yml")
-  );
+  const createAssetBucket = this.getPluginConfigValue("createAssetBucket");
+  
+  if (createAssetBucket) {
+    assetsBucketResource = await loadYml(
+      path.join(__dirname, "../resources/assets-bucket.yml")
+    );
 
-  assetsBucketResource.Resources.NextStaticAssetsS3Bucket.Properties.BucketName = bucketName;
+    assetsBucketResource.Resources.NextStaticAssetsS3Bucket.Properties.BucketName = bucketName;
 
-  this.serverless.service.resources = this.serverless.service.resources || {
-    Resources: {}
-  };
+    this.serverless.service.resources = this.serverless.service.resources || {
+      Resources: {}
+    };
 
-  merge(
-    this.serverless.service.provider.coreCloudFormationTemplate,
-    assetsBucketResource
-  );
+    merge(
+      this.serverless.service.provider.coreCloudFormationTemplate,
+      assetsBucketResource
+    );
+  }
 
   const cloudFront = this.getPluginConfigValue("cloudFront");
 

--- a/packages/serverless-nextjs-plugin/lib/checkForChanges.js
+++ b/packages/serverless-nextjs-plugin/lib/checkForChanges.js
@@ -2,6 +2,10 @@ const getAssetsBucketName = require("./getAssetsBucketName");
 
 module.exports = function() {
   const bucketName = getAssetsBucketName.call(this);
+  
+  if (!bucketName) {
+    return Promise.resolve();
+  }
 
   return this.provider
     .request("S3", "listObjectsV2", {

--- a/packages/serverless-nextjs-plugin/lib/checkForChanges.js
+++ b/packages/serverless-nextjs-plugin/lib/checkForChanges.js
@@ -3,7 +3,7 @@ const getAssetsBucketName = require("./getAssetsBucketName");
 module.exports = function() {
   const bucketName = getAssetsBucketName.call(this);
   const uploadBuildAssets = this.getPluginConfigValue("uploadBuildAssets");
-  
+
   if (!uploadBuildAssets || !bucketName) {
     return Promise.resolve();
   }

--- a/packages/serverless-nextjs-plugin/lib/checkForChanges.js
+++ b/packages/serverless-nextjs-plugin/lib/checkForChanges.js
@@ -2,8 +2,9 @@ const getAssetsBucketName = require("./getAssetsBucketName");
 
 module.exports = function() {
   const bucketName = getAssetsBucketName.call(this);
+  const uploadBuildAssets = this.getPluginConfigValue("uploadBuildAssets");
   
-  if (!bucketName) {
+  if (!uploadBuildAssets || !bucketName) {
     return Promise.resolve();
   }
 


### PR DESCRIPTION
This PR will add the option `createAssetBucket` with the default value set to `true`. It also fixes some issues where it would fail to deploy if the bucketName was resolved to `null` or `undefined`.

This fixes #100 and potentially #102 and #86 as well. It's also a workaround for #103 since it allows you to manually set up your bucket with unique resource names.