### PR TITLE
Allows next-aws-lambda to be found relative to node_modules

### DIFF
--- a/packages/serverless-nextjs-plugin/lib/__tests__/build.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/build.test.js
@@ -11,6 +11,7 @@ const PluginBuildDir = require("../../classes/PluginBuildDir");
 const getNextPagesFromBuildDir = require("../getNextPagesFromBuildDir");
 const NextPage = require("../../classes/NextPage");
 const ServerlessPluginBuilder = require("../../utils/test/ServerlessPluginBuilder");
+const findup = require("findup-sync");
 
 jest.mock("fs-extra");
 jest.mock("next/dist/build");
@@ -83,8 +84,11 @@ describe("build", () => {
 
   it("includes next-aws-lambda in node_modules/", () => {
     expect.assertions(1);
-
     const nextConfigDir = "path/to/next-app";
+    const nodeModulesRelativeFolder = path.relative(
+      nextConfigDir,
+      findup("node_modules")
+    );
 
     const parsedNextConfig = parsedNextConfigurationFactory();
     parseNextConfiguration.mockResolvedValueOnce(parsedNextConfig);
@@ -96,8 +100,9 @@ describe("build", () => {
     return build.call(plugin).then(() => {
       expect(plugin.serverless.service.package.include).toEqual(
         expect.arrayContaining([
-          "node_modules/next-aws-lambda/**/*.js",
-          "!node_modules/next-aws-lambda/**/*.test.js"
+          "path/to/next-app/sls-next-build/**",
+          `${nodeModulesRelativeFolder}/next-aws-lambda/**/*.js`,
+          `!${nodeModulesRelativeFolder}/next-aws-lambda/**/*.test.js`
         ])
       );
     });

--- a/packages/serverless-nextjs-plugin/lib/build.js
+++ b/packages/serverless-nextjs-plugin/lib/build.js
@@ -6,6 +6,7 @@ const logger = require("../utils/logger");
 const copyBuildFiles = require("./copyBuildFiles");
 const getNextPagesFromBuildDir = require("./getNextPagesFromBuildDir");
 const rewritePageHandlers = require("./rewritePageHandlers");
+const findup = require("findup-sync");
 
 const overrideTargetIfNotServerless = nextConfiguration => {
   const { target } = nextConfiguration;
@@ -28,12 +29,16 @@ module.exports = async function() {
   logger.log("Started building next app ...");
 
   const servicePackage = this.serverless.service.package;
-
+  const nodeModulesPath = path.relative(nextConfigDir, findup("node_modules"));
   servicePackage.include = servicePackage.include || [];
   servicePackage.include.push(
     path.posix.join(pluginBuildDir.posixBuildDir, "**"),
-    path.posix.join("node_modules/next-aws-lambda", "**", "*.js"),
-    path.posix.join("!node_modules/next-aws-lambda", "**", "*.test.js")
+    path.posix.join(`${nodeModulesPath}/next-aws-lambda`, "**", "*.js"),
+    `!${path.posix.join(
+      `${nodeModulesPath}/next-aws-lambda`,
+      "**",
+      "*.test.js"
+    )}`
   );
 
   const { nextConfiguration } = await parseNextConfiguration(nextConfigDir);

--- a/packages/serverless-nextjs-plugin/package.json
+++ b/packages/serverless-nextjs-plugin/package.json
@@ -24,6 +24,7 @@
     "@mapbox/s3urls": "^1.5.3",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
+    "findup-sync": "^4.0.0",
     "fs-extra": "^7.0.1",
     "js-yaml": "^3.12.1",
     "klaw": "^3.0.0",


### PR DESCRIPTION
This addresses #124 and #75. It allows `next-aws-lambda` to be found by determining where `node_modules` is relative to the `nextConfigDir`. It uses the very popular (and battle tested) `findup-sync` module to determine the *node_modules* folder. 