### PR TITLE
Fix: allow 'next-aws-lambda' to be found using require.resolve

### DIFF
--- a/packages/serverless-nextjs-plugin/lib/__tests__/build.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/build.test.js
@@ -11,7 +11,6 @@ const PluginBuildDir = require("../../classes/PluginBuildDir");
 const getNextPagesFromBuildDir = require("../getNextPagesFromBuildDir");
 const NextPage = require("../../classes/NextPage");
 const ServerlessPluginBuilder = require("../../utils/test/ServerlessPluginBuilder");
-const findup = require("findup-sync");
 
 jest.mock("fs-extra");
 jest.mock("next/dist/build");
@@ -85,9 +84,9 @@ describe("build", () => {
   it("includes next-aws-lambda in node_modules/", () => {
     expect.assertions(1);
     const nextConfigDir = "path/to/next-app";
-    const nodeModulesRelativeFolder = path.relative(
+    const nextAwsLambdaRelativePath = path.relative(
       nextConfigDir,
-      findup("node_modules")
+      path.dirname(require.resolve("next-aws-lambda"))
     );
 
     const parsedNextConfig = parsedNextConfigurationFactory();
@@ -101,8 +100,8 @@ describe("build", () => {
       expect(plugin.serverless.service.package.include).toEqual(
         expect.arrayContaining([
           "path/to/next-app/sls-next-build/**",
-          `${nodeModulesRelativeFolder}/next-aws-lambda/**/*.js`,
-          `!${nodeModulesRelativeFolder}/next-aws-lambda/**/*.test.js`
+          `${nextAwsLambdaRelativePath}/**/*.js`,
+          `!${nextAwsLambdaRelativePath}/**/*.test.js`
         ])
       );
     });

--- a/packages/serverless-nextjs-plugin/lib/build.js
+++ b/packages/serverless-nextjs-plugin/lib/build.js
@@ -6,7 +6,6 @@ const logger = require("../utils/logger");
 const copyBuildFiles = require("./copyBuildFiles");
 const getNextPagesFromBuildDir = require("./getNextPagesFromBuildDir");
 const rewritePageHandlers = require("./rewritePageHandlers");
-const findup = require("findup-sync");
 
 const overrideTargetIfNotServerless = nextConfiguration => {
   const { target } = nextConfiguration;
@@ -29,16 +28,15 @@ module.exports = async function() {
   logger.log("Started building next app ...");
 
   const servicePackage = this.serverless.service.package;
-  const nodeModulesPath = path.relative(nextConfigDir, findup("node_modules"));
+  const nextAwsLambdaPath = path.relative(
+    nextConfigDir,
+    path.dirname(require.resolve("next-aws-lambda"))
+  );
   servicePackage.include = servicePackage.include || [];
   servicePackage.include.push(
     path.posix.join(pluginBuildDir.posixBuildDir, "**"),
-    path.posix.join(`${nodeModulesPath}/next-aws-lambda`, "**", "*.js"),
-    `!${path.posix.join(
-      `${nodeModulesPath}/next-aws-lambda`,
-      "**",
-      "*.test.js"
-    )}`
+    path.posix.join(nextAwsLambdaPath, "**", "*.js"),
+    `!${path.posix.join(nextAwsLambdaPath, "**", "*.test.js")}`
   );
 
   const { nextConfiguration } = await parseNextConfiguration(nextConfigDir);

--- a/packages/serverless-nextjs-plugin/package.json
+++ b/packages/serverless-nextjs-plugin/package.json
@@ -24,7 +24,6 @@
     "@mapbox/s3urls": "^1.5.3",
     "chalk": "^2.4.2",
     "debug": "^4.1.1",
-    "findup-sync": "^4.0.0",
     "fs-extra": "^7.0.1",
     "js-yaml": "^3.12.1",
     "klaw": "^3.0.0",


### PR DESCRIPTION
This solution is more generalized than the previous one. It removes `findup-sync` and instead relies upon require.resolve. This fixes #75 and #124 