### PR TITLE
next-aws-lambda can now be consumed using async signature

### DIFF
--- a/packages/next-aws-lambda/README.md
+++ b/packages/next-aws-lambda/README.md
@@ -8,7 +8,16 @@ Compat layer between next.js serverless page and AWS Lambda.
 const compat = require("next-aws-lambda");
 const page = require(".next/serverless/pages/somePage.js");
 
+// using callback
+
 module.exports.render = (event, context, callback) => {
   compat(page)(event, context, callback);
+};
+
+// using async promise
+
+module.exports.render = async (event, context, callback) => {
+  const responsePromise = compat(page)(event, context); // don't pass the callback parameter
+  return responsePromise;
 };
 ```

--- a/packages/next-aws-lambda/__tests__/index.test.js
+++ b/packages/next-aws-lambda/__tests__/index.test.js
@@ -30,9 +30,7 @@ describe("next-aws-lambda", () => {
     expect(mockRender).toBeCalledWith(req, res);
     expect(mockDefault).not.toBeCalled();
   });
-});
 
-describe("next-aws-lambda", () => {
   it("passes request and response to next api", () => {
     const event = { foo: "bar" };
     const callback = () => {};
@@ -55,5 +53,27 @@ describe("next-aws-lambda", () => {
     compat(page)(event, context, callback);
 
     expect(mockDefault).toBeCalledWith(req, res);
+  });
+
+  it("supports async signature", () => {
+    expect.assertions(1);
+
+    const event = { foo: "bar" };
+    const context = {};
+    const page = {
+      render: () => {}
+    };
+    const response = {
+      statusCode: 200
+    };
+    compatLayer.mockReturnValue({
+      responsePromise: Promise.resolve(response)
+    });
+
+    const responsePromise = compat(page)(event, context);
+
+    return responsePromise.then(result => {
+      expect(result).toEqual(response);
+    });
   });
 });

--- a/packages/next-aws-lambda/index.js
+++ b/packages/next-aws-lambda/index.js
@@ -1,13 +1,17 @@
 const reqResMapper = require("./lib/compatLayer");
 
 const handlerFactory = page => (event, _context, callback) => {
-  const { req, res } = reqResMapper(event, callback);
+  const { req, res, responsePromise } = reqResMapper(event, callback);
   if (page.render instanceof Function) {
     // Is a React component
     page.render(req, res);
   } else {
     // Is an API
     page.default(req, res);
+  }
+
+  if (responsePromise) {
+    return responsePromise;
   }
 };
 

--- a/packages/next-aws-lambda/lib/__tests__/compatLayer.response.test.js
+++ b/packages/next-aws-lambda/lib/__tests__/compatLayer.response.test.js
@@ -20,6 +20,24 @@ describe("compatLayer.response", () => {
     res.end();
   });
 
+  it("[Promise] statusCode writeHead 404", async () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+
+    res.writeHead(404);
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.statusCode).toEqual(404);
+    });
+  });
+
   it("statusCode statusCode=200", done => {
     const { res } = create(
       {
@@ -36,6 +54,24 @@ describe("compatLayer.response", () => {
     );
     res.statusCode = 200;
     res.end();
+  });
+
+  it("[Promise] statusCode statusCode=200", () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+
+    res.statusCode = 200;
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.statusCode).toEqual(200);
+    });
   });
 
   it("writeHead headers", done => {
@@ -62,6 +98,30 @@ describe("compatLayer.response", () => {
     res.end();
   });
 
+  it("[Promise] writeHead headers", () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+
+    res.writeHead(200, {
+      "x-custom-1": "1",
+      "x-custom-2": "2"
+    });
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.multiValueHeaders).toEqual({
+        "x-custom-1": ["1"],
+        "x-custom-2": ["2"]
+      });
+    });
+  });
+
   it("setHeader", done => {
     const { res } = create(
       {
@@ -84,6 +144,28 @@ describe("compatLayer.response", () => {
     res.end();
   });
 
+  it("[Promise] setHeader", () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+
+    res.setHeader("x-custom-1", "1");
+    res.setHeader("x-custom-2", "2");
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.multiValueHeaders).toEqual({
+        "x-custom-1": ["1"],
+        "x-custom-2": ["2"]
+      });
+    });
+  });
+
   it("multi header support for api gateway", done => {
     const { res } = create(
       {
@@ -102,6 +184,25 @@ describe("compatLayer.response", () => {
     );
     res.setHeader("x-custom-1", ["1", "1"]);
     res.end();
+  });
+
+  it("[Promise] multi header support for api gateway", () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+    res.setHeader("x-custom-1", ["1", "1"]);
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.multiValueHeaders).toEqual({
+        "x-custom-1": ["1", "1"]
+      });
+    });
   });
 
   it("setHeader + removeHeader", done => {
@@ -124,6 +225,27 @@ describe("compatLayer.response", () => {
     res.setHeader("x-custom-2", "2");
     res.removeHeader("x-custom-1");
     res.end();
+  });
+
+  it("[Promise] setHeader + removeHeader", () => {
+    expect.assertions(1);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+    res.setHeader("x-custom-1", "1");
+    res.setHeader("x-custom-2", "2");
+    res.removeHeader("x-custom-1");
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.multiValueHeaders).toEqual({
+        "x-custom-2": ["2"]
+      });
+    });
   });
 
   it("getHeader/s", () => {
@@ -162,6 +284,24 @@ describe("compatLayer.response", () => {
     res.end();
   });
 
+  it(`[Promise] res.write('ok')`, () => {
+    expect.assertions(2);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+    res.write("ok");
+    res.end();
+
+    return responsePromise.then(response => {
+      expect(response.isBase64Encoded).toEqual(false);
+      expect(response.body).toEqual("ok");
+    });
+  });
+
   it(`res.end('ok')`, done => {
     const { res } = create(
       {
@@ -178,6 +318,23 @@ describe("compatLayer.response", () => {
       }
     );
     res.end("ok");
+  });
+
+  it(`[Promise] res.end('ok')`, () => {
+    expect.assertions(2);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+    res.end("ok");
+
+    return responsePromise.then(response => {
+      expect(response.isBase64Encoded).toEqual(false);
+      expect(response.body).toEqual("ok");
+    });
   });
 
   it("req.pipe(res)", done => {
@@ -199,6 +356,24 @@ describe("compatLayer.response", () => {
     res.end("ok");
   });
 
+  it("[Promise] req.pipe(res)", () => {
+    expect.assertions(2);
+
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+
+    res.end("ok");
+
+    return responsePromise.then(response => {
+      expect(response.isBase64Encoded).toEqual(false);
+      expect(response.body).toEqual("ok");
+    });
+  });
+
   it("base64 support", done => {
     process.env.BINARY_SUPPORT = "yes";
     const { res } = create(
@@ -216,5 +391,24 @@ describe("compatLayer.response", () => {
       }
     );
     res.end("ok");
+  });
+
+  it("[Promise] base64 support", () => {
+    expect.assertions(2);
+
+    process.env.BINARY_SUPPORT = "yes";
+    const { res, responsePromise } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+
+    res.end("ok");
+
+    return responsePromise.then(response => {
+      expect(response.body).toEqual(Buffer.from("ok").toString("base64"));
+      expect(response.isBase64Encoded).toEqual(true);
+    });
   });
 });

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -121,8 +121,9 @@ const reqResMapper = (event, callback) => {
 
   if (event.body) {
     req.push(event.body, event.isBase64Encoded ? "base64" : undefined);
-    req.push(null);
   }
+
+  req.push(null);
 
   function fixApiGatewayMultipleHeaders() {
     for (const key of Object.keys(response.multiValueHeaders)) {

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -9,6 +9,7 @@ const reqResMapper = (event, callback) => {
     statusCode: 200,
     multiValueHeaders: {}
   };
+  let responsePromise;
 
   const req = new Stream.Readable();
   req.url = (event.requestContext.path || event.path || "").replace(
@@ -93,7 +94,8 @@ const reqResMapper = (event, callback) => {
   res.getHeaders = () => {
     return res.headers;
   };
-  res.end = text => {
+
+  const onResEnd = (callback, resolve) => text => {
     if (text) res.write(text);
     response.body = Buffer.from(response.body).toString(
       base64Support ? "base64" : undefined
@@ -101,12 +103,26 @@ const reqResMapper = (event, callback) => {
     response.multiValueHeaders = res.headers;
     res.writeHead(response.statusCode);
     fixApiGatewayMultipleHeaders();
-    callback(null, response);
+
+    if (callback) {
+      callback(null, response);
+    } else {
+      resolve(response);
+    }
   };
+
+  if (typeof callback === "function") {
+    res.end = onResEnd(callback);
+  } else {
+    responsePromise = new Promise(resolve => {
+      res.end = onResEnd(null, resolve);
+    });
+  }
+
   if (event.body) {
     req.push(event.body, event.isBase64Encoded ? "base64" : undefined);
+    req.push(null);
   }
-  req.push(null);
 
   function fixApiGatewayMultipleHeaders() {
     for (const key of Object.keys(response.multiValueHeaders)) {
@@ -116,7 +132,7 @@ const reqResMapper = (event, callback) => {
     }
   }
 
-  return { req, res };
+  return { req, res, responsePromise };
 };
 
 module.exports = reqResMapper;

--- a/packages/serverless-nextjs-plugin/lib/getFactoryHandlerCode.js
+++ b/packages/serverless-nextjs-plugin/lib/getFactoryHandlerCode.js
@@ -6,9 +6,10 @@ const lambdaHandlerWithFactory = `
   const page = require("${PAGE_BUNDLE_PATH}");
   const handlerFactory = require("${HANDLER_FACTORY_PATH}");
 
-  module.exports.render = (event, context, callback) => {
+  module.exports.render = async (event, context) => {
     const handler = handlerFactory(page);
-    handler(event, context, callback);
+    const responsePromise = handler(event, context);
+    return responsePromise;
   };
 `;
 


### PR DESCRIPTION
`next-aws-lambda` now supports async promises:

```js
// using async promise

module.exports.render = async (event, context, callback) => {
  const responsePromise = compat(page)(event, context); // don't pass the callback parameter
  return responsePromise;
};
```

Also updated usage in the plugin to use this approach.

Closes https://github.com/danielcondemarin/serverless-nextjs-plugin/issues/125